### PR TITLE
Typed array (and factory) changed

### DIFF
--- a/tools/PHPStorm/ApacheVelocityLanguage/ArrayIterator.php
+++ b/tools/PHPStorm/ApacheVelocityLanguage/ArrayIterator.php
@@ -8,19 +8,19 @@ namespace ${NAMESPACE};
 #end
 class ${NAME} extends \ArrayIterator implements ${NAME}Interface
 {
-     /** @param ${elementType}Interface ...${DS}${arrayItemName}s */
+    /** @param ${elementType}Interface ...${DS}${arrayItemName}s */
     public function __construct(array ${DS}${arrayItemName}s = array(), int ${DS}flags = 0)
     {
         if (!empty(${DS}${arrayItemName}s)) {
-            ${DS}this->_assertValidArrayType(...${DS}${arrayItemName}s);
+        ${DS}this->_assertValidArrayType(...${DS}${arrayItemName}s);
         }
 
         parent::__construct(${DS}${arrayItemName}s, ${DS}flags);
     }
 
     public function offsetGet(${DS}index): ${elementType}Interface
-    {
-        return ${DS}this->_assertValidArrayItemType(parent::offsetGet(${DS}index));
+{
+return ${DS}this->_assertValidArrayItemType(parent::offsetGet(${DS}index));
     }
 
     /** @param ${elementType}Interface ${DS}${arrayItemName} */
@@ -37,9 +37,9 @@ class ${NAME} extends \ArrayIterator implements ${NAME}Interface
     }
 
     public function current(): ${elementType}Interface
-    {
-        return parent::current();
-    }
+{
+return parent::current();
+}
 
     protected function _assertValidArrayItemType(${elementType}Interface ${DS}${arrayItemName})
     {
@@ -47,7 +47,12 @@ class ${NAME} extends \ArrayIterator implements ${NAME}Interface
     }
 
     protected function _assertValidArrayType(${elementType}Interface ...${DS}${arrayItemName}s): ${NAME}Interface
-    {
-        return ${DS}this;
+{
+return ${DS}this;
+    }
+
+    public function getArrayCopy(): ${NAME}Interface
+{
+return new self(parent::getArrayCopy(), (int)${DS}this->getFlags());
     }
 }

--- a/tools/PHPStorm/ApacheVelocityLanguage/ArrayIteratorInterface.php
+++ b/tools/PHPStorm/ApacheVelocityLanguage/ArrayIteratorInterface.php
@@ -8,7 +8,7 @@ namespace ${NAMESPACE};
 #end
 interface ${NAME} extends \SeekableIterator, \ArrayAccess, \Serializable, \Countable
 {
-     /** @param ${elementType}Interface ...${DS}${arrayItemName}s */
+    /** @param ${elementType}Interface ...${DS}${arrayItemName}s */
     public function __construct(array ${DS}${arrayItemName}s = array(), int ${DS}flags = 0);
 
     public function offsetGet(${DS}index): ${elementType}Interface;
@@ -20,4 +20,6 @@ interface ${NAME} extends \SeekableIterator, \ArrayAccess, \Serializable, \Count
     public function append(${DS}${arrayItemName});
 
     public function current(): ${elementType}Interface;
+
+    public function getArrayCopy(): $NAME;
 }

--- a/tools/PHPStorm/ApacheVelocityLanguage/Factory.php
+++ b/tools/PHPStorm/ApacheVelocityLanguage/Factory.php
@@ -1,4 +1,5 @@
 #set( $unqualifiedClassName = "$NAMESPACE.substring($NAMESPACE.lastIndexOf('\')).substring(1)" )
+#set( $isArrayFactory = "$NAMESPACE.endsWith('Array')" )
 <?php
 declare(strict_types=1);
 
@@ -14,6 +15,10 @@ class Factory implements FactoryInterface
 
     public function create(): ${unqualifiedClassName}Interface
     {
+        #if ( $isArrayFactory == "true" )
+        return ${DS}this->_get${targetClassVariable}()->getArrayCopy();
+        #else
         return clone ${DS}this->_get${targetClassVariable}();
+        #
     }
 }


### PR DESCRIPTION
I dunno why the formatting got all weird, important things are that `getArrayCopy()` is implemented