### PR TITLE
Dont cast large number-like strings (e.g. dynamo ids) 

### DIFF
--- a/http/fab/SearchCriteria/ServerRequest/Builder.php
+++ b/http/fab/SearchCriteria/ServerRequest/Builder.php
@@ -44,7 +44,7 @@ class Builder implements BuilderInterface
 
     protected function cast(string $string)
     {
-        if (is_numeric($string) & (int)$string < PHP_INT_MAX) {
+        if (is_numeric($string) && (int)$string < PHP_INT_MAX) {
             if (ctype_digit($string)) {
                 return (int)$string;
             } else {


### PR DESCRIPTION
Don't cast number-like strings (e.g. dynamo ids) if they are larger than PHP_INT_MAX as their value is not preserved.