### PR TITLE
Remove SearchCriteria prototype modification

### DIFF
--- a/http/fab/SearchCriteria.yml
+++ b/http/fab/SearchCriteria.yml
@@ -2,8 +2,8 @@ services:
   Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteriaInterface:
     class: Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria
     calls:
-    - [setSearchCriteriaFilterMap, ['@Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\Filter\MapInterface']]
-    - [setSearchCriteriaSortOrderMap, ['@Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\SortOrder\MapInterface']]
-    - [setSearchCriteriaVisitorMap, ['@Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\Visitor\MapInterface']]
-    - [addVisitor, ['@Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\Doctrine\DBAL\Query\QueryBuilder\VisitorInterface']]
+    - [setSearchCriteriaFilterMapFactory, ['@Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\Filter\Map\FactoryInterface']]
+    - [setSearchCriteriaSortOrderMapFactory, ['@Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\SortOrder\Map\FactoryInterface']]
+    - [setSearchCriteriaVisitorMapFactory, ['@Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\Visitor\Map\FactoryInterface']]
+    - [setSearchCriteriaDoctrineDBALQueryQueryBuilderVisitorFactory, ['@Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\Doctrine\DBAL\Query\QueryBuilder\Visitor\FactoryInterface']]
     shared: false

--- a/http/fab/SearchCriteria/Visitor/Map/Factory/AwareTrait.php
+++ b/http/fab/SearchCriteria/Visitor/Map/Factory/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\Visitor\Map\Factory;
+
+use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\SearchCriteria\Visitor\Map\FactoryInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsReplaceThisWithTheNameOfYourProductSearchCriteriaVisitorMapFactory;
+
+    public function setSearchCriteriaVisitorMapFactory(FactoryInterface $searchCriteriaVisitorMapFactory) : self
+    {
+        if ($this->hasSearchCriteriaVisitorMapFactory()) {
+            throw new \LogicException('NeighborhoodsReplaceThisWithTheNameOfYourProductSearchCriteriaVisitorMapFactory is already set.');
+        }
+        $this->NeighborhoodsReplaceThisWithTheNameOfYourProductSearchCriteriaVisitorMapFactory = $searchCriteriaVisitorMapFactory;
+
+        return $this;
+    }
+
+    protected function getSearchCriteriaVisitorMapFactory() : FactoryInterface
+    {
+        if (!$this->hasSearchCriteriaVisitorMapFactory()) {
+            throw new \LogicException('NeighborhoodsReplaceThisWithTheNameOfYourProductSearchCriteriaVisitorMapFactory is not set.');
+        }
+
+        return $this->NeighborhoodsReplaceThisWithTheNameOfYourProductSearchCriteriaVisitorMapFactory;
+    }
+
+    protected function hasSearchCriteriaVisitorMapFactory() : bool
+    {
+        return isset($this->NeighborhoodsReplaceThisWithTheNameOfYourProductSearchCriteriaVisitorMapFactory);
+    }
+
+    protected function unsetSearchCriteriaVisitorMapFactory() : self
+    {
+        if (!$this->hasSearchCriteriaVisitorMapFactory()) {
+            throw new \LogicException('NeighborhoodsReplaceThisWithTheNameOfYourProductSearchCriteriaVisitorMapFactory is not set.');
+        }
+        unset($this->NeighborhoodsReplaceThisWithTheNameOfYourProductSearchCriteriaVisitorMapFactory);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
PHP's `clone` is shallow, so injecting `Map`s into a prototype instance of an actor and then `clone`ing the prototype just copies over references to those `Map`s, meaning all instances of that actor will be pointing to the same `Map` instances. These changes modify the prototype `SearchCriteria` to ensure references aren't shared across `SearchCriteria` instances