### PR TITLE
Remove deprecated Symfony ContainerBuilder RepeatedPass

### DIFF
--- a/http/fab/Symfony/Component/DependencyInjection/ContainerBuilder/Facade.php
+++ b/http/fab/Symfony/Component/DependencyInjection/ContainerBuilder/Facade.php
@@ -88,8 +88,8 @@ class Facade implements FacadeInterface
     {
         if ($this->containerIsBuilt === false) {
             $containerBuilder = $this->getContainerBuilder();
-
-            $passes = [new AnalyzeServiceReferencesPass(), new InlineServiceDefinitionsPass()];
+            $containerBuilder->addCompilerPass(new AnalyzeServiceReferencesPass());
+            $containerBuilder->addCompilerPass(new InlineServiceDefinitionsPass());
             $containerBuilder->compile(true);
             $this->containerIsBuilt = true;
         } else {


### PR DESCRIPTION
I was getting an error trying to run prefab after `composer update`:
```
Fatal error: Uncaught ErrorException: The "Symfony\Component\DependencyInjection\Compiler\RepeatedPass" class is deprecated since Symfony 4.2. in /var/www/html/listing_service.neighborhoods.com/vendor/symfony/dependency-injection/Compiler/RepeatedPass.php on line 14

ErrorException: The "Symfony\Component\DependencyInjection\Compiler\RepeatedPass" class is deprecated since Symfony 4.2. in /var/www/html/listing_service.neighborhoods.com/vendor/symfony/dependency-injection/Compiler/RepeatedPass.php on line 14

Call Stack:
    0.0080     404960   1. {main}() /var/www/html/listing_service.neighborhoods.com/vendor/neighborhoods/prefab/bin/prefab:0
    0.2498    2766040   2. Neighborhoods\Prefab\Prefab->generate() /var/www/html/listing_service.neighborhoods.com/vendor/neighborhoods/prefab/bin/prefab:22
    0.2498    2766040   3. Neighborhoods\Prefab\Protean\Container\Builder->build() /var/www/html/listing_service.neighborhoods.com/vendor/neighborhoods/prefab/src/Prefab.php:18
    0.2498    2766040   4. Neighborhoods\Prefab\Protean\Container\Builder->getContainer() /var/www/html/listing_service.neighborhoods.com/vendor/neighborhoods/prefab/src/Protean/Container/Builder.php:19
    0.2498    2766040   5. Neighborhoods\Prefab\Protean\Container\Builder->getSymfonyContainerBuilder() /var/www/html/listing_service.neighborhoods.com/vendor/neighborhoods/prefab/src/Protean/Container/Builder.php:27
    1.3052    4340744   6. Neighborhoods\Prefab\Symfony\Component\DependencyInjection\ContainerBuilder\Facade->build() /var/www/html/listing_service.neighborhoods.com/vendor/neighborhoods/prefab/src/Protean/Container/Builder.php:44
    1.3169    4517064   7. spl_autoload_call(???) /var/www/html/listing_service.neighborhoods.com/vendor/neighborhoods/prefab/fab/Symfony/Component/DependencyInjection/ContainerBuilder/Facade.php:94
    1.3169    4517160   8. Composer\Autoload\ClassLoader->loadClass(???) /var/www/html/listing_service.neighborhoods.com/vendor/neighborhoods/prefab/fab/Symfony/Component/DependencyInjection/ContainerBuilder/Facade.php:94
    1.3169    4517160   9. Composer\Autoload\includeFile(???) /var/www/html/listing_service.neighborhoods.com/vendor/composer/ClassLoader.php:322
    1.3189    4523840  10. include('/var/www/html/listing_service.neighborhoods.com/vendor/symfony/dependency-injection/Compiler/RepeatedPass.php') /var/www/html/listing_service.neighborhoods.com/vendor/composer/ClassLoader.php:444
    1.3189    4524160  11. trigger_error(???, ???) /var/www/html/listing_service.neighborhoods.com/vendor/symfony/dependency-injection/Compiler/RepeatedPass.php:14
    1.3189    4525272  12. {closure:/var/www/html/listing_service.neighborhoods.com/vendor/neighborhoods/prefab/bin/prefab:5-13}(???, ???, ???, ???, ???) /var/www/html/listing_service.neighborhoods.com/vendor/symfony/dependency-injection/Compiler/RepeatedPass.php:14
```

This PR removes the only usage of that class