### PR TITLE
Remove prefab's own copy of the RepeatedPass class

### DIFF
--- a/fab/Symfony/Component/DependencyInjection/ContainerBuilder/Facade.php
+++ b/fab/Symfony/Component/DependencyInjection/ContainerBuilder/Facade.php
@@ -7,7 +7,6 @@ use Neighborhoods\Prefab\Symfony\Component\Finder\Map;
 use Neighborhoods\Prefab\Symfony\Component\Finder\MapInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Compiler\RepeatedPass;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\InlineServiceDefinitionsPass;
@@ -89,10 +88,8 @@ class Facade implements FacadeInterface
     {
         if ($this->containerIsBuilt === false) {
             $containerBuilder = $this->getContainerBuilder();
-
-            $passes = [new AnalyzeServiceReferencesPass(), new InlineServiceDefinitionsPass()];
-            $repeatedPass = new RepeatedPass($passes);
-            $repeatedPass->process($containerBuilder);
+            $containerBuilder->addCompilerPass(new AnalyzeServiceReferencesPass());
+            $containerBuilder->addCompilerPass(new InlineServiceDefinitionsPass());
             $containerBuilder->compile(true);
             $this->containerIsBuilt = true;
         } else {


### PR DESCRIPTION
In https://github.com/neighborhoods/Prefab/pull/80 I only modified the `ContainerBuilder\Facade` class that's copied over to fabbed services, we also need to modify the copy Prefab uses internally