### PR TITLE
Instantiate (i.e. clone) maps properly

### DIFF
--- a/src/Actor/MapFactory/Generator.php
+++ b/src/Actor/MapFactory/Generator.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\Actor\MapFactory;
+
+use Neighborhoods\Prefab\ClassSaverInterface;
+use Neighborhoods\Prefab\Console\GeneratorInterface;
+use Neighborhoods\Prefab\Console\GeneratorMetaInterface;
+use Symfony\Component\Yaml\Yaml;
+use Zend\Code\Generator\ClassGenerator;
+use Zend\Code\Generator\FileGenerator;
+use Zend\Code\Reflection\ClassReflection;
+use Neighborhoods\Prefab\ClassSaver;
+use Neighborhoods\Prefab\StringReplacer;
+
+class Generator implements GeneratorInterface
+{
+    use ClassSaver\Factory\AwareTrait;
+    use StringReplacer\Factory\AwareTrait;
+
+    public const CLASS_NAME = 'Factory';
+
+    /** @var ClassGenerator */
+    protected $generator;
+    /** @var ClassSaverInterface */
+    protected $classSaver;
+    /** @var GeneratorMetaInterface */
+    protected $meta;
+
+    public function generate() : GeneratorInterface
+    {
+        $this->setGenerator();
+
+        $this->getGenerator()->setNamespaceName($this->getMeta()->getActorNamespace());
+        $this->getGenerator()->addTrait('AwareTrait');
+        $this->getGenerator()->setImplementedInterfaces([$this->getMeta()->getActorNamespace() . '\FactoryInterface']);
+        $this->getGenerator()->setName(self::CLASS_NAME);
+
+        $this->replaceReturnTypePlaceHolders();
+
+        $file = new FileGenerator();
+        $file->setClass($this->getGenerator());
+
+        $builtFile = $this->replaceEntityPlaceholders($file->generate());
+
+        $this->getClassSaverFactory()->create()
+            ->setClassName(self::CLASS_NAME)
+            ->setGeneratedClass($builtFile)
+            ->setSavePath($this->getMeta()->getActorFilePath())
+            ->saveClass();
+
+        $this->generateService();
+
+        return $this;
+    }
+
+    protected function generateService() : GeneratorInterface
+    {
+        $class = $this->getMeta()->getActorNamespace() . '\\Factory';
+        $interface = $this->getMeta()->getActorNamespace() . '\\FactoryInterface';
+
+        $factoryPrefix = $this->getTruncatedNamespace();
+
+        $yaml = [
+            'services' => [
+                $interface => [
+                    'class' => $class,
+                    'public' => false,
+                    'shared' => true,
+                    'calls' => [
+                        [ "set{$factoryPrefix}", ["@{$this->getMeta()->getActorNamespace()}Interface" ]]
+                    ]
+                ]
+            ]
+        ];
+
+        $preparedYaml = Yaml::dump($yaml, 4, 2);
+        file_put_contents($this->getMeta()->getActorFilePath() . '/' . self::CLASS_NAME . '.yml', $preparedYaml);
+
+        return $this;
+    }
+
+    protected function getTruncatedNamespace() : string
+    {
+        $namespaceArray = explode('\\', $this->getMeta()->getActorNamespace());
+        unset($namespaceArray[0]);
+        unset($namespaceArray[1]);
+        return implode('', $namespaceArray);
+    }
+
+    protected function replaceReturnTypePlaceHolders() : GeneratorInterface
+    {
+        $methods = $this->getGenerator()->getMethods();
+
+        foreach ($methods as $method) {
+            $returnType = $method->getReturnType();
+            if ($returnType && strpos($returnType->generate(), 'DAONAMEPLACEHOLDERInterface')) {
+                $method->setReturnType($this->getMeta()->getActorNamespace() . 'Interface');
+            }
+        }
+
+        return $this;
+    }
+
+    protected function replaceEntityPlaceholders(string $fileContent) : string
+    {
+        return $this->getStringReplacerFactory()
+            ->create()
+            ->setNamespace($this->getMeta()->getActorNamespace())
+            ->setFile($fileContent)
+            ->replacePlaceholders();
+    }
+
+    protected function setGenerator() : GeneratorInterface
+    {
+        $template = new ClassReflection(Template::class);
+        $this->generator = ClassGenerator::fromReflection($template);
+        return $this;
+    }
+
+    protected function getGenerator() : ClassGenerator
+    {
+        if ($this->generator === null) {
+            throw new \LogicException('Generator generator has not been set');
+        }
+
+        return $this->generator;
+    }
+
+    public function getMeta(): GeneratorMetaInterface
+    {
+        if ($this->meta === null) {
+            throw new \LogicException('Generator meta has not been set.');
+        }
+        return $this->meta;
+    }
+
+    public function setMeta(GeneratorMetaInterface $meta): GeneratorInterface
+    {
+        if ($this->meta !== null) {
+            throw new \LogicException('Generator meta is already set.');
+        }
+        $this->meta = $meta;
+        return $this;
+    }
+
+    public function getActorName(): string
+    {
+        return self::CLASS_NAME;
+    }
+}

--- a/src/Actor/MapFactory/Generator.yml
+++ b/src/Actor/MapFactory/Generator.yml
@@ -1,0 +1,8 @@
+services:
+  Neighborhoods\Prefab\Actor\MapFactory\GeneratorInterface:
+    class: Neighborhoods\Prefab\Actor\MapFactory\Generator
+    public: false
+    shared: false
+    calls:
+    - [setClassSaverFactory, ['@Neighborhoods\Prefab\ClassSaver\FactoryInterface']]
+    - [setStringReplacerFactory, ['@Neighborhoods\Prefab\StringReplacer\FactoryInterface']]

--- a/src/Actor/MapFactory/Generator/AwareTrait.php
+++ b/src/Actor/MapFactory/Generator/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\Actor\MapFactory\Generator;
+
+use Neighborhoods\Prefab\Console\GeneratorInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsPrefabActorMapFactoryGenerator;
+
+    public function setActorMapFactoryGenerator(GeneratorInterface $actorMapFactoryGenerator): self
+    {
+        if ($this->hasActorMapFactoryGenerator()) {
+            throw new \LogicException('NeighborhoodsPrefabActorMapFactoryGenerator is already set.');
+        }
+        $this->NeighborhoodsPrefabActorMapFactoryGenerator = $actorMapFactoryGenerator;
+
+        return $this;
+    }
+
+    protected function getActorMapFactoryGenerator(): GeneratorInterface
+    {
+        if (!$this->hasActorMapFactoryGenerator()) {
+            throw new \LogicException('NeighborhoodsPrefabActorMapFactoryGenerator is not set.');
+        }
+
+        return $this->NeighborhoodsPrefabActorMapFactoryGenerator;
+    }
+
+    protected function hasActorMapFactoryGenerator(): bool
+    {
+        return isset($this->NeighborhoodsPrefabActorMapFactoryGenerator);
+    }
+
+    protected function unsetActorMapFactoryGenerator(): self
+    {
+        if (!$this->hasActorMapFactoryGenerator()) {
+            throw new \LogicException('NeighborhoodsPrefabActorMapFactoryGenerator is not set.');
+        }
+        unset($this->NeighborhoodsPrefabActorMapFactoryGenerator);
+
+        return $this;
+    }
+}

--- a/src/Actor/MapFactory/Generator/Factory.php
+++ b/src/Actor/MapFactory/Generator/Factory.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\Actor\MapFactory\Generator;
+
+use Neighborhoods\Prefab\Console\GeneratorInterface;
+
+/** @codeCoverageIgnore */
+class Factory implements FactoryInterface
+{
+    use AwareTrait;
+
+    public function create(): GeneratorInterface
+    {
+        return clone $this->getActorMapFactoryGenerator();
+    }
+}

--- a/src/Actor/MapFactory/Generator/Factory.yml
+++ b/src/Actor/MapFactory/Generator/Factory.yml
@@ -1,0 +1,5 @@
+services:
+  Neighborhoods\Prefab\Actor\MapFactory\Generator\FactoryInterface:
+    class: Neighborhoods\Prefab\Actor\MapFactory\Generator\Factory
+    calls:
+    - [setActorMapFactoryGenerator, ['@Neighborhoods\Prefab\Actor\MapFactory\GeneratorInterface']]

--- a/src/Actor/MapFactory/Generator/Factory/AwareTrait.php
+++ b/src/Actor/MapFactory/Generator/Factory/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\Actor\MapFactory\Generator\Factory;
+
+use Neighborhoods\Prefab\Actor\MapFactory\Generator\FactoryInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsPrefabActorMapFactoryGeneratorFactory;
+
+    public function setActorMapFactoryGeneratorFactory(FactoryInterface $actorMapFactoryGeneratorFactory): self
+    {
+        if ($this->hasActorMapFactoryGeneratorFactory()) {
+            throw new \LogicException('NeighborhoodsPrefabActorMapFactoryGeneratorFactory is already set.');
+        }
+        $this->NeighborhoodsPrefabActorMapFactoryGeneratorFactory = $actorMapFactoryGeneratorFactory;
+
+        return $this;
+    }
+
+    protected function getActorMapFactoryGeneratorFactory(): FactoryInterface
+    {
+        if (!$this->hasActorMapFactoryGeneratorFactory()) {
+            throw new \LogicException('NeighborhoodsPrefabActorMapFactoryGeneratorFactory is not set.');
+        }
+
+        return $this->NeighborhoodsPrefabActorMapFactoryGeneratorFactory;
+    }
+
+    protected function hasActorMapFactoryGeneratorFactory(): bool
+    {
+        return isset($this->NeighborhoodsPrefabActorMapFactoryGeneratorFactory);
+    }
+
+    protected function unsetActorMapFactoryGeneratorFactory(): self
+    {
+        if (!$this->hasActorMapFactoryGeneratorFactory()) {
+            throw new \LogicException('NeighborhoodsPrefabActorMapFactoryGeneratorFactory is not set.');
+        }
+        unset($this->NeighborhoodsPrefabActorMapFactoryGeneratorFactory);
+
+        return $this;
+    }
+}

--- a/src/Actor/MapFactory/Generator/FactoryInterface.php
+++ b/src/Actor/MapFactory/Generator/FactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\Actor\MapFactory\Generator;
+
+use Neighborhoods\Prefab\Console\GeneratorInterface;
+
+/** @codeCoverageIgnore */
+interface FactoryInterface
+{
+    public function create(): GeneratorInterface;
+}

--- a/src/Actor/MapFactory/Template.php
+++ b/src/Actor/MapFactory/Template.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\Actor\MapFactory;
+
+/** @codeCoverageIgnore */
+class Template // Implements FactoryInterface
+{
+
+    // use AwareTrait
+
+    public function create() : DAONAMEPLACEHOLDERInterface
+    {
+        return $this->getDAOVARNAMEPLACEHOLDER()->getArrayCopy();
+    }
+}

--- a/src/BuildPlan/Builder.php
+++ b/src/BuildPlan/Builder.php
@@ -21,6 +21,7 @@ use Neighborhoods\Prefab\Actor\MapBuilder;
 use Neighborhoods\Prefab\Actor\MapBuilderInterface;
 use Neighborhoods\Prefab\Actor\Map;
 use Neighborhoods\Prefab\Actor\MapInterface;
+use Neighborhoods\Prefab\Actor\MapFactory;
 use Neighborhoods\Prefab\Actor\Repository;
 use Neighborhoods\Prefab\Actor\RepositoryInterface;
 use Neighborhoods\Prefab\Console\GeneratorMeta;
@@ -37,6 +38,7 @@ class Builder implements BuilderInterface
     use Handler\Generator\Factory\AwareTrait;
     use HandlerInterface\Generator\Factory\AwareTrait;
     use Map\Generator\Factory\AwareTrait;
+    use MapFactory\Generator\Factory\AwareTrait;
     use MapBuilder\Generator\Factory\AwareTrait;
     use MapBuilderInterface\Generator\Factory\AwareTrait;
     use MapInterface\Generator\Factory\AwareTrait;
@@ -232,8 +234,22 @@ class Builder implements BuilderInterface
         $this->addAwareTraitToPlan($nextLevelMeta);
         $this->addMapBuilderToPlan($nextLevelMeta);
         $this->addMapBuilderInterfaceToPlan($nextLevelMeta);
-        $this->addFactoryToPlan($nextLevelMeta);
+        $this->addMapFactoryToPlan($nextLevelMeta);
         $this->addRepositoryToPlan($nextLevelMeta);
+
+        return $this;
+    }
+
+    protected function addMapFactoryToPlan(GeneratorMetaInterface $mapFactoryMeta) : BuilderInterface
+    {
+        $mapFactoryGenerator = $this->getActorMapFactoryGeneratorFactory()->create();
+        $mapFactoryGenerator->setMeta($mapFactoryMeta);
+        $this->appendGeneratorToBuildPlan($mapFactoryGenerator);
+        $this->addFactoryInterfaceToPlan($mapFactoryMeta);
+
+        $nextLevelMeta = $this->getNextLevelMeta($mapFactoryGenerator);
+
+        $this->addAwareTraitToPlan($nextLevelMeta);
 
         return $this;
     }

--- a/src/BuildPlan/Builder.yml
+++ b/src/BuildPlan/Builder.yml
@@ -19,3 +19,4 @@ services:
       - [setActorAwareTraitGeneratorFactory, ['@Neighborhoods\Prefab\Actor\AwareTrait\Generator\FactoryInterface']]
       - [setActorDAOInterfaceGeneratorFactory, ['@Neighborhoods\Prefab\Actor\DAOInterface\Generator\FactoryInterface']]
       - [setActorDAOGeneratorFactory, ['@Neighborhoods\Prefab\Actor\DAO\Generator\FactoryInterface']]
+      - [setActorMapFactoryGeneratorFactory, ['@Neighborhoods\Prefab\Actor\MapFactory\Generator\FactoryInterface']]


### PR DESCRIPTION
Fixes https://github.com/neighborhoods/Prefab/issues/84

The now-obsolete AVLTs checked if the actor for which you were trying to create a `Factory` was an `Array` or `Map`, and, if it was, used `ArrayIterator::getArrayCopy()` instead of `clone`, but Prefab simply used `clone` for all actors

I duplicated all the `Actor\Factory` logic into an `Actor\MapFactory`, modifying only the `Factory::create()` method

I tested this locally, but you guys will probably want a `FitnessFunction/UseCase` for this change