### PR TITLE
Make sure Prefab splits on the fab directory

### DIFF
--- a/src/BuildPlan/Builder.php
+++ b/src/BuildPlan/Builder.php
@@ -69,10 +69,10 @@ class Builder implements BuilderInterface
         // Get the namespace based on the filepath
         $namespacePrefix = 'Neighborhoods\\' . $this->getBuildConfiguration()->getProjectName();
 
-        $filepathArray = explode('fab', $actorFilePath);
+        $filepathArray = explode('/fab/', $actorFilePath);
         $namespaceSuffix = $filepathArray[count($filepathArray) - 1];
         $namespaceSuffix = str_replace('/', '\\', $namespaceSuffix);
-        $namespace = $namespacePrefix . $namespaceSuffix;
+        $namespace = $namespacePrefix . '\\' . $namespaceSuffix;
 
         $daoMeta->setDaoName($this->getDaoName());
         $daoMeta->setActorNamespace($namespace);


### PR DESCRIPTION
This would cause errors if a file path happened to have the letters `fab` in them. This makes sure we are splitting on the actual `fab/` directory.

I could learn how to git, but making a new pr is easier.