### PR TITLE
AUT-12 Expose services as public in tests

### DIFF
--- a/http/fab/Prefab5/Protean/Container/Builder.php
+++ b/http/fab/Prefab5/Protean/Container/Builder.php
@@ -15,6 +15,8 @@ use Zend\Expressive\Application;
 
 class Builder implements BuilderInterface
 {
+    protected const SHOULD_REGISTER_ALL_SERVICES_AS_PUBLIC_DEFAULT = false;
+
     protected $container;
     protected $symfony_container_builder;
     protected $service_ids_registered_for_public_access = [];
@@ -210,7 +212,8 @@ class Builder implements BuilderInterface
     public function getShouldRegisterAllServicesAsPublic() : bool
     {
         if (null === $this->shouldRegisterAllServicesAsPublic) {
-            throw new \LogicException('Builder shouldRegisterAllServicesAsPublic has not been set.');
+            $this->shouldRegisterAllServicesAsPublic =
+                static::SHOULD_REGISTER_ALL_SERVICES_AS_PUBLIC_DEFAULT;
         }
 
         return $this->shouldRegisterAllServicesAsPublic;


### PR DESCRIPTION
This PR adds a mechanism for exposing all service definitions and aliases as public for use in a testing context.

Here is a link to a conversation on Flowdock about this topic: https://www.flowdock.com/app/neighborhoods/prefab-1/threads/U3Iu5bWGqg42ZHF2mOm3GAwkg0X

https://55places.atlassian.net/browse/AUT-12