### PR TITLE
Bugfix | Add depth to composer finder

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -106,7 +106,7 @@ class Generator implements GeneratorInterface
     protected function getProjectNameFromComposer() : string
     {
         $finder = new Finder();
-        $finder->name('composer.json')->in($this->projectDir)->exclude('vendor');
+        $finder->name('composer.json')->in($this->projectDir)->depth('== 0');
 
         $matchCount = $finder->count();
         if ($matchCount < 1) {


### PR DESCRIPTION
No need to search the entire project for `composer.json`. Speeds up getting the project name, by a lot.