### PR TITLE
Remove deprecated methods

### DIFF
--- a/http/fab/Prefab5/Protean/Container/Builder.php
+++ b/http/fab/Prefab5/Protean/Container/Builder.php
@@ -44,9 +44,6 @@ class Builder implements BuilderInterface
                 $containerClass = sprintf('\\%s', $this->getContainerName());
                 $containerBuilder = new $containerClass;
             } else {
-                if ($this->getCanBuildZendExpressive()) {
-                    $this->buildZendExpressive();
-                }
                 $this->cacheSymfonyContainerBuilder();
                 $containerBuilder = $this->getSymfonyContainerBuilder();
             }
@@ -54,23 +51,6 @@ class Builder implements BuilderInterface
         }
 
         return $this->container;
-    }
-
-    /** @deprecated */
-    public function setCanBuildZendExpressive(bool $can_build_zend_expressive) : BuilderInterface
-    {
-        if ($this->can_build_zend_expressive !== null) {
-            throw new \LogicException('Builder can_build_zend_expressive is already set.');
-        }
-
-        $this->can_build_zend_expressive = $can_build_zend_expressive;
-
-        return $this;
-    }
-
-    protected function getCanBuildZendExpressive() : bool
-    {
-        return $this->can_build_zend_expressive === true;
     }
 
     protected function getSymfonyContainerBuilder() : ContainerBuilder

--- a/http/fab/Prefab5/Protean/Container/BuilderInterface.php
+++ b/http/fab/Prefab5/Protean/Container/BuilderInterface.php
@@ -15,9 +15,7 @@ interface BuilderInterface
     public function registerServiceAsPublic(string $serviceId): BuilderInterface;
 
     public function buildZendExpressive(): BuilderInterface;
-
-    public function setCanBuildZendExpressive(bool $canBuildZendExpressive): BuilderInterface;
-
+    
     public function setContainerName(string $containerName): BuilderInterface;
 
     public function getContainerName(): string;


### PR DESCRIPTION
This method was deprecated in 5.x and this PR removes them from 6.x.  Users now just call `->buildZendExpressive()` instead of setting `->canBuildZendExpressive()`.