### PR TITLE
Lock Bradfab Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": "^7.2",
     "jsoumelidis/zend-sf-di-config": "^0.3",
-    "neighborhoods/bradfab": "^1.0-beta",
+    "neighborhoods/bradfab": "1.0.0-beta8",
     "neighborhoods/bakery": "^1.0",
     "doctrine/dbal": "^2.7",
     "symfony/config": "^4.0",


### PR DESCRIPTION
I thought this was already done but I think I failed to commit it when integrating Bradfab. This will prevent Bradfab API changes from breaking Prefab