### PR TITLE
PREF-125 Fix FQCN

### DIFF
--- a/http/config/autoload/dependencies.global.php
+++ b/http/config/autoload/dependencies.global.php
@@ -21,7 +21,7 @@ return [
         // Use 'factories' for services provided by callbacks/factory classes.
         'factories'  => [
             // Fully\Qualified\ClassName::class => Fully\Qualified\FactoryName::class,
-            \Zend\ProblemDetails\ProblemDetailsResponseFactory::class => \Neighborhoods\PropertyService\Prefab5\Zend\ProblemDetails\ProblemDetailsResponseFactoryFactory::class,
+            \Zend\ProblemDetails\ProblemDetailsResponseFactory::class => \Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\Zend\ProblemDetails\ProblemDetailsResponseFactoryFactory::class,
         ],
     ],
 ];


### PR DESCRIPTION
The string `PropertyService` was accidentally hardcoded into a file under `http`. Replacing it with `ReplaceThisWithTheNameOfYourProduct` should allow Prefab to automagically replace that string with the base namespace of a given Prefab project.