### PR TITLE
Correct casing for HTTPBuildableDirectoryMap

### DIFF
--- a/docs/BuildableDirectories.md
+++ b/docs/BuildableDirectories.md
@@ -48,7 +48,7 @@ declare(strict_types=1);
 error_reporting(E_ALL);
 
 require_once __DIR__ . '/../vendor/autoload.php';
-use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HttpBuildableDirectoryMap\ContainerBuilder;
+use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildableDirectoryMap\ContainerBuilder;
 
 $primer = new ContainerBuilder\Primer();
 $primer->primeContainers();

--- a/http/fab/Prefab5/HTTP.php
+++ b/http/fab/Prefab5/HTTP.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HttpBuildableDirectoryMap;
+use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildableDirectoryMap;
 use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\Opcache;
 use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\Protean;
 use Zend\Expressive\Application;
@@ -14,7 +14,7 @@ use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\Opcache\HTTPBuilda
 class HTTP implements HTTPInterface
 {
     use Protean\Container\Builder\AwareTrait;
-    use HttpBuildableDirectoryMap\ContainerBuilder\AwareTrait;
+    use HTTPBuildableDirectoryMap\ContainerBuilder\AwareTrait;
 
     public function respond() : HTTPInterface
     {
@@ -44,7 +44,7 @@ class HTTP implements HTTPInterface
             return $this->getProteanContainerBuilder();
         }
 
-        return $this->getPrefab5HttpBuildableDirectoryMapContainerBuilder()
+        return $this->getPrefab5HTTPBuildableDirectoryMapContainerBuilder()
             ->setProteanContainerBuilder($this->getProteanContainerBuilder())
             ->setBuildableDirectoryMap($httpBuildableDirectoryMap)
             ->setDirectoryGroup($this->getUrlRoot())

--- a/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder/AwareTrait.php
+++ b/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder/AwareTrait.php
@@ -1,45 +1,45 @@
 <?php
 declare(strict_types=1);
 
-namespace Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HttpBuildableDirectoryMap\ContainerBuilder;
+namespace Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildableDirectoryMap\ContainerBuilder;
 
-use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HttpBuildableDirectoryMap\ContainerBuilderInterface;
+use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildableDirectoryMap\ContainerBuilderInterface;
 
 /** @codeCoverageIgnore */
 trait AwareTrait
 {
-    protected $NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HttpBuildableDirectoryMapContainerBuilder;
+    protected $NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HTTPBuildableDirectoryMapContainerBuilder;
 
-    public function setPrefab5HttpBuildableDirectoryMapContainerBuilder(ContainerBuilderInterface $prefab5HttpBuildableDirectoryMapContainerBuilder) : self
+    public function setPrefab5HTTPBuildableDirectoryMapContainerBuilder(ContainerBuilderInterface $prefab5HTTPBuildableDirectoryMapContainerBuilder) : self
     {
-        if ($this->hasPrefab5HttpBuildableDirectoryMapContainerBuilder()) {
-            throw new \LogicException('NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HttpBuildableDirectoryMapContainerBuilder is already set.');
+        if ($this->hasPrefab5HTTPBuildableDirectoryMapContainerBuilder()) {
+            throw new \LogicException('NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HTTPBuildableDirectoryMapContainerBuilder is already set.');
         }
-        $this->NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HttpBuildableDirectoryMapContainerBuilder = $prefab5HttpBuildableDirectoryMapContainerBuilder;
+        $this->NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HTTPBuildableDirectoryMapContainerBuilder = $prefab5HTTPBuildableDirectoryMapContainerBuilder;
 
         return $this;
     }
 
-    protected function getPrefab5HttpBuildableDirectoryMapContainerBuilder() : ContainerBuilderInterface
+    protected function getPrefab5HTTPBuildableDirectoryMapContainerBuilder() : ContainerBuilderInterface
     {
-        if (!$this->hasPrefab5HttpBuildableDirectoryMapContainerBuilder()) {
-            throw new \LogicException('NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HttpBuildableDirectoryMapContainerBuilder is not set.');
+        if (!$this->hasPrefab5HTTPBuildableDirectoryMapContainerBuilder()) {
+            throw new \LogicException('NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HTTPBuildableDirectoryMapContainerBuilder is not set.');
         }
 
-        return $this->NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HttpBuildableDirectoryMapContainerBuilder;
+        return $this->NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HTTPBuildableDirectoryMapContainerBuilder;
     }
 
-    protected function hasPrefab5HttpBuildableDirectoryMapContainerBuilder() : bool
+    protected function hasPrefab5HTTPBuildableDirectoryMapContainerBuilder() : bool
     {
-        return isset($this->NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HttpBuildableDirectoryMapContainerBuilder);
+        return isset($this->NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HTTPBuildableDirectoryMapContainerBuilder);
     }
 
-    protected function unsetPrefab5HttpBuildableDirectoryMapContainerBuilder() : self
+    protected function unsetPrefab5HTTPBuildableDirectoryMapContainerBuilder() : self
     {
-        if (!$this->hasPrefab5HttpBuildableDirectoryMapContainerBuilder()) {
-            throw new \LogicException('NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HttpBuildableDirectoryMapContainerBuilder is not set.');
+        if (!$this->hasPrefab5HTTPBuildableDirectoryMapContainerBuilder()) {
+            throw new \LogicException('NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HTTPBuildableDirectoryMapContainerBuilder is not set.');
         }
-        unset($this->NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HttpBuildableDirectoryMapContainerBuilder);
+        unset($this->NeighborhoodsReplaceThisWithTheNameOfYourProductPrefab5HTTPBuildableDirectoryMapContainerBuilder);
 
         return $this;
     }

--- a/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder/Primer.php
+++ b/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder/Primer.php
@@ -5,7 +5,7 @@ namespace Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildabl
 
 use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\Opcache;
 use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\Opcache\HTTPBuildableDirectoryMap\BuildableDirectoryFileNotFound;
-use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HttpBuildableDirectoryMap\ContainerBuilder;
+use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildableDirectoryMap\ContainerBuilder;
 use Neighborhoods\ReplaceThisWithTheNameOfYourProduct\Prefab5\Protean\Container\Builder;
 
 class Primer implements PrimerInterface

--- a/http/public/index.php
+++ b/http/public/index.php
@@ -24,7 +24,7 @@ $httpBuildableDirectoryContainerBuilder = new HTTPBuildableDirectoryMap\Containe
 
 $HTTP = (new HTTP())
     ->setProteanContainerBuilder($proteanContainerBuilder)
-    ->setPrefab5HttpBuildableDirectoryMapContainerBuilder($httpBuildableDirectoryContainerBuilder)
+    ->setPrefab5HTTPBuildableDirectoryMapContainerBuilder($httpBuildableDirectoryContainerBuilder)
     ->respond();
 
 return;


### PR DESCRIPTION
This PR corrects a few more references to the `HTTPBuildableDirectoryMap` object.