### PR TITLE
MLSS-845 Check if dir exists before attempting to create

### DIFF
--- a/src/Actor/DAO/Generator.php
+++ b/src/Actor/DAO/Generator.php
@@ -153,7 +153,9 @@ EOF;
         $preparedYaml = Yaml::dump($yaml, 4, 2);
         $serviceFileDirectoryPath = $this->getMeta()->getActorFilePath() . '/' . $this->getActorName();
 
-        mkdir($serviceFileDirectoryPath);
+        if (!file_exists($serviceFileDirectoryPath)) {
+            mkdir($serviceFileDirectoryPath);
+        }
 
         file_put_contents(
             $serviceFileDirectoryPath . '/' . $this->getActorName() . '.service.yml',


### PR DESCRIPTION
This PR updates the logic that creates a DAO's directory to check whether the directory exists before attempting to create it.

I discovered this bug when attempting to run Prefab on ListingService, and saw this error:

```bash
➜  ListingService git:(MLSS-845-use-per-endpoint-containers) ✗ composer prebake
> vendor/bin/prefab

>> Copying the skeleton...
>> Success.
>> Assembling the Prefab build plan...
>> Success.
>> Generating Prefab machinery...

Fatal error: Uncaught ErrorException: mkdir(): File exists in /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Actor/DAO/Generator.php:156
Stack trace:
#0 [internal function]: {closure}(2, 'mkdir(): File e...', '/Users/timothyr...', 156, Array)
#1 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Actor/DAO/Generator.php(156): mkdir('/Users/timothyr...')
#2 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Actor/DAO/Generator.php(72): Neighborhoods\Prefab\Actor\DAO\Generator->generateService()
#3 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/BuildPlan.php(15): Neighborhoods\Prefab\Actor\DAO\Generator->generate()
#4 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Generator.php(142): Neighborhoods\Prefab\BuildPlan->execute()
#5 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Generator.php(57): Neighborhoods\Prefab\Generator->generatePrefab()
#6 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Prefa in /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Actor/DAO/Generator.php on line 156
PHP Fatal error:  Uncaught ErrorException: mkdir(): File exists in /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Actor/DAO/Generator.php:156
Stack trace:
#0 [internal function]: {closure}(2, 'mkdir(): File e...', '/Users/timothyr...', 156, Array)
#1 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Actor/DAO/Generator.php(156): mkdir('/Users/timothyr...')
#2 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Actor/DAO/Generator.php(72): Neighborhoods\Prefab\Actor\DAO\Generator->generateService()
#3 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/BuildPlan.php(15): Neighborhoods\Prefab\Actor\DAO\Generator->generate()
#4 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Generator.php(142): Neighborhoods\Prefab\BuildPlan->execute()
#5 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Generator.php(57): Neighborhoods\Prefab\Generator->generatePrefab()
#6 /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Prefa in /Users/timothyrouke/ListingService/vendor/neighborhoods/prefab/src/Actor/DAO/Generator.php on line 156
```