### PR TITLE
make sure path exists in src/ before including it

### DIFF
--- a/http/fab/Prefab5/Protean/Container/Builder/DiscoverableDirectories.php
+++ b/http/fab/Prefab5/Protean/Container/Builder/DiscoverableDirectories.php
@@ -132,7 +132,10 @@ class DiscoverableDirectories implements DiscoverableDirectoriesInterface
     {
         if (!empty($this->getFilters())) {
             foreach ($this->getFilters() as $directoryFilter) {
-                $this->addFullPath(sprintf('%s/%s', $this->getSourceDirectoryPath(), $directoryFilter));
+                $fullPathCandidate = sprintf('%s/%s', $this->getSourceDirectoryPath(), $directoryFilter);
+                if ($this->getFilesystem()->exists($fullPathCandidate)) {
+                    $this->addFullPath($fullPathCandidate);
+                }
             }
         } else {
             $this->addFullPath($this->getSourceDirectoryPath());


### PR DESCRIPTION
Otherwise \Symfony\Component\Finder\Finder::in throws an \InvalidArgumentException with the message `The "%s" directory does not exist.`

Non-blocking, as it looks like I need to include a higher level directory anyway.