### PR TITLE
PREF-133 | Append directory separator to path to prevent false matches

### DIFF
--- a/http/fab/Prefab5/Protean/Container/Builder/DiscoverableDirectories.php
+++ b/http/fab/Prefab5/Protean/Container/Builder/DiscoverableDirectories.php
@@ -40,13 +40,18 @@ class DiscoverableDirectories implements DiscoverableDirectoriesInterface
 
     public function addDirectoryPathFilter(string $directoryPathFilter) : DiscoverableDirectoriesInterface
     {
+        $directoryPathFilter = (substr($directoryPathFilter, -1) === '/')
+            ? $directoryPathFilter
+            : $directoryPathFilter . '/';
+
         if (isset($this->directory_filters[$directoryPathFilter])) {
             throw new \LogicException(
                 sprintf('FilesystemProperties directory_filter[%s] is already set.', $directoryPathFilter)
             );
         }
         foreach ($this->directory_filters as $existingDirectoryFilter) {
-            if (strpos($existingDirectoryFilter, $directoryPathFilter) === 0) {
+            if (strpos($existingDirectoryFilter, $directoryPathFilter) === 0
+                || strpos($directoryPathFilter, $existingDirectoryFilter) === 0) {
                 throw new \LogicException(
                     sprintf(
                         'FilesystemProperties directory_filter[%s] is a parent node of [%s].',


### PR DESCRIPTION
- Added logic to append directory separator to directory path, if necessary, before checking if the path is a parent node of an existing directory filter.
- Added another strpos conditional to compare both paths going the opposite direction to prevent ordering from bypassing the check. (Created [ticket](https://55places.atlassian.net/browse/PREF-150) to revisit this logic to maybe use sorting on all added directories instead of checking the entire array every time a new value is added)