### PR TITLE
PREF-170 | Chmod data/* to have correct permissions

### DIFF
--- a/src/HttpSkeleton/Generator.php
+++ b/src/HttpSkeleton/Generator.php
@@ -43,6 +43,7 @@ class Generator implements GeneratorInterface
 
         $this->getFileSystem()->mirror($this->getStagedDirectory(), $this->getTargetDirectory(), null, $options);
         $this->getFileSystem()->remove($this->getStagedDirectory());
+        $this->getFileSystem()->chmod($this->getTargetDirectory() . 'data', 0755, umask(), true);
 
         return $this;
     }


### PR DESCRIPTION
Services can remove the `RUN chmod -R a+rw data/cache/` line from their Dockerfile which is the cause of containers failing to build before prefab has been run. Prefab will now handle assigning the permissions to the `data/cache` dir