### PR TITLE
Hotfix | Remove data/cache chmod

### DIFF
--- a/src/HttpSkeleton/Generator.php
+++ b/src/HttpSkeleton/Generator.php
@@ -43,7 +43,6 @@ class Generator implements GeneratorInterface
 
         $this->getFileSystem()->mirror($this->getStagedDirectory(), $this->getTargetDirectory(), null, $options);
         $this->getFileSystem()->remove($this->getStagedDirectory());
-        $this->getFileSystem()->chmod($this->getTargetDirectory() . 'data', 0766, umask(), true);
 
         return $this;
     }


### PR DESCRIPTION
Removed call to chmod the `data/cache` dir because it is breaking dev/prod environments.