### PR TITLE
PREF 214 | Make top level DAO key in Prefab Definition Files Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A code generation tool. Takes the busywork out of building strongly-typed, patte
 
 ### Running Prefab
 - In your composer file, ensure you have your project name defined. Use the `composer-example.json` file, found in the root of Prefab, as a template
-- Create your `dao.prefab.definition.yml` file as outlined [below](#Prefab Definition File Specification).
+- Create your `Actor.prefab.definition.yml` file as outlined [below](#Prefab Definition File Specification).
 - From the root of your project run `./vendor/bin/prefab`
     - This will add all of the supporting files needed to create a working API endpoint
 
@@ -15,83 +15,81 @@ Working examples of Prefab can be found in the [PrefabFitness repository](https:
 
 ## Prefab Definition File Specification
 
-The purpose of this document is to define the components needed to generate an HTTP endpoint for a DAO from a `.prefab.definition.yml` file
+The purpose of this document is to define the components needed to generate an HTTP endpoint for an actor from a `.prefab.definition.yml` file
 
-The file must be named {DAONAME}.prefab.definition.yml and saved under `src/`. They should be stored in the same nested directory structure as you would like the machinery to be generated under `fab/`.  
-- `dao`
-    - `table_name`
-        - Name of the database table containing the data that populates the DAO
-    - `supporting_actor_group`
-        - The collection of supporting actors you need generated for the actor
-        - Can be one of `complete`, `collection`, or `minimal`
-        - This field is optional and defaults to `complete`
-        - See [below](#supporting-actor-groups) for more information
-    - `http_route`
-        - The http route that corresponds with the DAO
-        - This field is optional
-    - `http_verbs`
-        - HTTP methods allowed for a DAO. Can include get, post, put, patch, and delete.
-        - Note: Since mutative and destructive actions are not yet patterned for repositories, you will need to override the generated handler to call the proper repository method.
-    - `identity_field`
-        - Name of the database column containing the unique identifier for a given DAO
-    - `properties`
-        - The class properties of the DAO. Each property should have:
-            - `data_type`
-                - The type of object the property represents. This can be a primitive or a fully qualified namespaced object
-                - Note: This used to be called `php_type` which is maintained for backwards compatibility
-            - `record_key`
-                - Name of the key containing the data that populates the class property
-                - Note: This used to be called `database_column_name` which is still maintained for backwards compatibility 
-            - `nullable`
-                - Whether or not this property can be null. If true, the builder method will surround this property with isset() before attempting to set the value on the DAO
-                - If not set, defaults to false
-            - `created_on_insert`
-                - This denotes properties that are not expected to be present before inserting the record into the database.
-                - If true, the buildForInsert() method will surround this property with isset() before attempting to set the value on the DAO. However, the build() method will still require this property when building a record from the database.
-                - If not set, defaults to false
+The file must be named {ACTORNAME}.prefab.definition.yml and saved under `src/`. They should be stored in the same nested directory structure as you would like the machinery to be generated under `fab/`.  
+- `table_name`
+    - Name of the database table containing the data that populates the actor
+- `supporting_actor_group`
+    - The collection of supporting actors you need generated for the actor
+    - Can be one of `complete`, `collection`, or `minimal`
+    - This field is optional and defaults to `complete`
+    - See [below](#supporting-actor-groups) for more information
+- `http_route`
+    - The HTTP route to access the actor
+    - This field is optional and unnecessary if you don't want to expose the actor to HTTP traffic
+- `http_verbs`
+    - HTTP methods allowed for an actor. Can include `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`.
+    - Note: Since mutative and destructive actions are not yet patterned for repositories, you will need to override the generated handler to call the proper repository method.
+- `identity_field`
+    - Name of the database column that uniquely identifies a record for the actor
+- `properties`
+    - The class properties of the actor. Each property should have:
+        - `data_type`
+            - The type of object the property represents. This can be a primitive or a fully qualified namespaced object
+            - Note: This used to be called `php_type` which is maintained for backwards compatibility
+        - `record_key`
+            - Name of the key containing the data that populates the class property
+            - Note: This used to be called `database_column_name` which is still maintained for backwards compatibility 
+        - `nullable`
+            - Whether or not this property can be null. If true, the builder method will surround this property with isset() before attempting to set the value on the actor
+            - If not set, defaults to false
+        - `created_on_insert`
+            - This denotes properties that are not expected to be present before inserting the record into the database.
+            - If true, the buildForInsert() method will surround this property with isset() before attempting to set the value on the actor. However, the build() method will still require this property when building a record from the database.
+            - If not set, defaults to false
                 
 Prefab also enforces
 * A contract version namespace (e.g. `MV1`, `DOR1`, `RETS1`, etc.). This MUST be present under `src/`.
 * A `{VENDOR}\{PRODUCT_NAME}` PSR-4 namespace convention (e.g. `Neighborhoods\Prefab`). This MUST be defined in `composer.json`.
 
-### Example structure of a DAO yaml file:
+### Example structure of a Prefab definition file:
 
 Filename: `User.prefab.definition.yml`
 ```yaml
-dao:
-  table_name: mv1_user
-  identity_field: id
-  supporting_actor_group: complete
-  http_route: /mv1/users/{searchCriteria:}
-  http_verbs:
-   - get
-   - post
-   - put
-   - patch
-   - delete
-  properties:
-    id:
-      data_type: int
-      record_key: id
-      nullable: false
-      created_on_insert: true
-    email:
-      data_type: string
-      record_key: email
-      nullable: true
-    first_name:
-      data_type: string
-      record_key: first_name
-      nullable: false
-    last_name:
-      data_type: string
-      record_key: last_name
-      nullable: false
-    created_at:
-      data_type: string
-      record_key: created_at
-      nullable: false
-      created_on_insert: true
+table_name: mv1_user
+identity_field: id
+supporting_actor_group: complete
+http_route: /mv1/users/{searchCriteria:}
+http_verbs:
+- get
+- post
+- put
+- patch
+- delete
+properties:
+id:
+  data_type: int
+  record_key: id
+  nullable: false
+  created_on_insert: true
+email:
+  data_type: string
+  record_key: email
+  nullable: true
+first_name:
+  data_type: string
+  record_key: first_name
+  nullable: false
+last_name:
+  data_type: string
+  record_key: last_name
+  nullable: false
+created_at:
+  data_type: string
+  record_key: created_at
+  nullable: false
+  created_on_insert: true
 ```
 ## Search Criteria
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "neighborhoods/prefab",
   "type": "library",
   "description": "Neighborhoods Prefab builds Protean machinery.",
-  "license": "proprietary",
+  "license": "MIT",
   "keywords": [],
   "bin": [
     "bin/prefab"

--- a/src/BuildConfiguration/Builder.php
+++ b/src/BuildConfiguration/Builder.php
@@ -20,36 +20,40 @@ class Builder implements BuilderInterface
     public function build() : BuildConfigurationInterface
     {
         $buildConfiguration = $this->getBuildConfigurationFactory()->create();
-        $configArray = $this->getConfigFromYaml();
+        $prefabDefinitionFileArray = $this->getConfigFromYaml();
 
-        $buildConfiguration->setTableName($configArray['dao']['table_name'])
+        if (isset($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_DAO])) {
+            $prefabDefinitionFileArray = $prefabDefinitionFileArray[BuildConfigurationInterface::KEY_DAO];
+        }
+        
+        $buildConfiguration->setTableName($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_TABLE_NAME])
             ->setRootSaveLocation($this->getFabDirFromYamlPath())
             ->setProjectDir($this->getProjectRoot())
             ->setProjectName($this->getProjectName());
 
-        $buildConfiguration->setDaoName($configArray['dao']['name']);
+        $buildConfiguration->setDaoName($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_NAME]);
 
         $buildConfiguration->setActorNamespace($this->buildActorNamespace());
 
-        if (!empty($configArray['dao']['identity_field'])) {
-            $buildConfiguration->setDaoIdentityField($configArray['dao']['identity_field']);
+        if (!empty($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_IDENTITY_FIELD])) {
+            $buildConfiguration->setDaoIdentityField($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_IDENTITY_FIELD]);
         }
 
-        if (!empty($configArray['dao']['http_route'])) {
-            $buildConfiguration->setHttpRoute($configArray['dao']['http_route']);
-            $httpVerbs = ($configArray['dao']['http_verbs']) ?? ['GET'];
+        if (!empty($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_HTTP_ROUTE])) {
+            $buildConfiguration->setHttpRoute($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_HTTP_ROUTE]);
+            $httpVerbs = ($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_HTTP_VERBS]) ?? [BuildConfigurationInterface::HTTP_VERB_GET];
             $buildConfiguration->setHttpVerbs($httpVerbs);
         }
 
-        if (!empty($configArray['dao']['supporting_actor_group'])) {
-            $buildConfiguration->setSupportingActorGroup($configArray['dao']['supporting_actor_group']);
+        if (!empty($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_SUPPORTING_ACTOR_GROUP])) {
+            $buildConfiguration->setSupportingActorGroup($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_SUPPORTING_ACTOR_GROUP]);
         } else {
             $buildConfiguration->setSupportingActorGroup(BuildConfigurationInterface::SUPPORTING_ACTOR_GROUP_COMPLETE);
         }
 
-        foreach ($configArray['dao']['properties'] as $key => $values) {
+        foreach ($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_PROPERTIES] as $key => $values) {
             $record = $values;
-            $record['name'] = $key;
+            $record[BuildConfigurationInterface::KEY_NAME] = $key;
 
             $buildConfiguration->appendDaoProperty(
                 $this->getDaoPropertyBuilderFactory()->create()

--- a/src/BuildConfigurationInterface.php
+++ b/src/BuildConfigurationInterface.php
@@ -9,6 +9,16 @@ interface BuildConfigurationInterface
     public const SUPPORTING_ACTOR_GROUP_COLLECTION = 'collection';
     public const SUPPORTING_ACTOR_GROUP_MINIMAL = 'minimal';
 
+    public const KEY_DAO = 'dao';
+    public const KEY_TABLE_NAME = 'table_name';
+    public const KEY_NAME = 'name';
+    public const KEY_IDENTITY_FIELD = 'identity_field';
+    public const KEY_HTTP_ROUTE = 'http_route';
+    public const KEY_HTTP_VERBS = 'http_verbs';
+    public const HTTP_VERB_GET = 'GET';
+    public const KEY_SUPPORTING_ACTOR_GROUP = 'supporting_actor_group';
+    public const KEY_PROPERTIES = 'properties';
+
     public function getTableName() : string;
 
     public function setTableName(string $tableName) : BuildConfigurationInterface;


### PR DESCRIPTION
- Make top level DAO key optional in Prefab definition files
- Move string in BuildConfiguration Builder to constants in the BuildConfigurationInterface
- Update composer file to new license
- Update README to remove references to the top level DAO key
- Update README to replace references to DAO with Actor