### PR TITLE
Use vendor name from build configuration when checking for complex objects

### DIFF
--- a/BuphaloTemplates/Prefab5/Actor/Map/Builder.php
+++ b/BuphaloTemplates/Prefab5/Actor/Map/Builder.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 namespace Neighborhoods\BuphaloTemplateTree\Actor\Map;
 
 use Neighborhoods\BuphaloTemplateTree\Actor\MapInterface;

--- a/src/ActorConfiguration/Actor/Builder.php
+++ b/src/ActorConfiguration/Actor/Builder.php
@@ -9,23 +9,20 @@ interface Builder
 {
     public const ACTOR_KEY = '<ActorName>/Builder.php';
     public const TEMPLATE_PATH = 'Actor/Builder.php';
-    public const BUILD_METHOD_ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Builder-build';
-    public const BUILD_FOR_INSERT_METHOD_ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Builder-buildForInsert';
-    public const BUILDER_FACTORY_AWARE_TRAITS_ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Builder-AwareTraits';
 
     public const ANNOTATION_PROCESSORS = [
         [
-            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => self::BUILD_METHOD_ANNOTATION_PROCESSOR_KEY,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Builder::ANNOTATION_PROCESSOR_KEY,
             AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Builder\BuildMethod\Builder::class,
             AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Builder::class,
         ],
         [
-            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => self::BUILD_FOR_INSERT_METHOD_ANNOTATION_PROCESSOR_KEY,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => \Neighborhoods\Prefab\AnnotationProcessor\Actor\BuilderBuildForInsertMethod::ANNOTATION_PROCESSOR_KEY,
             AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Builder\BuildForInsertMethod\Builder::class,
             AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\Actor\BuilderBuildForInsertMethod::class,
         ],
         [
-            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => self::BUILDER_FACTORY_AWARE_TRAITS_ANNOTATION_PROCESSOR_KEY,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => \Neighborhoods\Prefab\AnnotationProcessor\Actor\BuilderFactoryTrait::ANNOTATION_PROCESSOR_KEY,
             AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Builder\BuilderFactoryAwareTraits\Builder::class,
             AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\Actor\BuilderFactoryTrait::class,
         ],

--- a/src/ActorConfiguration/Actor/BuilderServiceFile.php
+++ b/src/ActorConfiguration/Actor/BuilderServiceFile.php
@@ -3,9 +3,17 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\ActorConfiguration\Actor;
 
+use Neighborhoods\Prefab\AnnotationProcessorRecordInterface;
+
 interface BuilderServiceFile
 {
     public const ACTOR_KEY = '<ActorName>/Builder.service.yml';
     public const TEMPLATE_PATH = 'Actor/Builder.service.yml';
-    public const ANNOTATION_PROCESSORS = [];
+    public const ANNOTATION_PROCESSORS = [
+        [
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => \Neighborhoods\Prefab\AnnotationProcessor\Actor\BuilderServiceFile::ANNOTATION_PROCESSOR_KEY,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\BuilderServiceFile\FactorySetters\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\Actor\BuilderServiceFile::class,
+        ]
+    ];
 }

--- a/src/AnnotationProcessor/Actor/BuilderFactoryTrait.php
+++ b/src/AnnotationProcessor/Actor/BuilderFactoryTrait.php
@@ -8,17 +8,17 @@ use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
 
 class BuilderFactoryTrait implements AnnotationProcessorInterface
 {
+    const STATIC_CONTEXT_RECORD_KEY_DATA_TYPE = 'data_type';
     protected $context;
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Builder-AwareTraits';
 
-    protected const NEIGHBORHOODS_NAMESPACE = '\\Neighborhoods\\';
+    public const STATIC_CONTEXT_RECORD_KEY_VENDOR = 'vendor';
 
-    protected const COMPLEX_OBJECT_BUILDER_METHOD = <<< EOF
-    \$Actor->set%s(
-            \$this->get%sBuilderFactory()->create()->setRecord(\$record[ActorInterface::PROP_%s])->build()
-    );
-EOF;
+    public const STATIC_CONTEXT_RECORD_KEY_PROPERTIES = 'properties';
+    public const ACTOR_PROPERTY_KEY_NULLABLE = 'nullable';
+    public const ACTOR_PROPERTY_KEY_DATA_TYPE = 'data_type';
+    public const ACTOR_PROPERTY_KEY_CREATED_ON_INSERT = 'created_on_insert';
 
     public function getAnnotationProcessorContext() : ContextInterface
     {
@@ -39,17 +39,19 @@ EOF;
 
     public function getReplacement() : string
     {
-        $properties = $this->getAnnotationProcessorContext()->getStaticContextRecord()['properties'];
+        $properties = $this->getAnnotationProcessorContext()->getStaticContextRecord()[self::STATIC_CONTEXT_RECORD_KEY_PROPERTIES];
 
         $replacement = '';
 
         $builtTraits = [];
         foreach ($properties as $propertyName => $property) {
-
-            if ($this->isPropertyComplexObject($property['data_type']) && ! in_array($property['data_type'], $builtTraits)) {
-                $dataType = str_replace('Interface', '', $property['data_type']);
+            if (
+                $this->isPropertyComplexObject($property[self::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE])
+                && !in_array($property[self::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE], $builtTraits)
+            ) {
+                $dataType = str_replace('Interface', '', $property[self::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE]);
                 $replacement .= "\tuse " . $dataType . '\\Builder\\Factory\\AwareTrait;' . PHP_EOL;
-                $builtTraits[] = $property['data_type'];
+                $builtTraits[] = $property[self::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE];
             }
         }
 
@@ -58,6 +60,6 @@ EOF;
 
     protected function isPropertyComplexObject(string $type) : bool
     {
-        return strpos($type, self::NEIGHBORHOODS_NAMESPACE) === 0;
+        return strpos($type,  '\\' . $this->getAnnotationProcessorContext()->getStaticContextRecord()[self::STATIC_CONTEXT_RECORD_KEY_VENDOR]) === 0;
     }
 }

--- a/src/AnnotationProcessor/Actor/BuilderServiceFile.php
+++ b/src/AnnotationProcessor/Actor/BuilderServiceFile.php
@@ -12,10 +12,14 @@ class BuilderServiceFile implements AnnotationProcessorInterface
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\BuilderServiceFile';
 
-    protected const NEIGHBORHOODS_NAMESPACE = '\\Neighborhoods\\';
+    public const STATIC_CONTEXT_RECORD_KEY_VENDOR = 'vendor';
+    public const STATIC_CONTEXT_RECORD_KEY_PROPERTIES = 'properties';
+
+    public const ACTOR_PROPERTY_KEY_DATA_TYPE = 'data_type';
+
     protected const BUILDER_FACTORY_SET_METHOD_PATTERN =
-"      - [set%sBuilderFactory, ['@%s\Builder\FactoryInterface']]
-";
+"      - [set%sBuilderFactory, ['@%s\Builder\FactoryInterface']]\n";
+
     public function getAnnotationProcessorContext() : ContextInterface
     {
         if ($this->context === null) {
@@ -35,17 +39,17 @@ class BuilderServiceFile implements AnnotationProcessorInterface
 
     public function getReplacement() : string
     {
-        $properties = $this->getAnnotationProcessorContext()->getStaticContextRecord()['properties'];
+        $properties = $this->getAnnotationProcessorContext()->getStaticContextRecord()[self::STATIC_CONTEXT_RECORD_KEY_PROPERTIES];
 
         $replacement = '';
         $builtDataTypes = [];
         foreach ($properties as $propertyName => $property) {
-            $propertyType = $property['data_type'];
+            $propertyType = $property[self::ACTOR_PROPERTY_KEY_DATA_TYPE];
             if ($this->isPropertyComplexObject($propertyType) && !in_array($propertyType, $builtDataTypes)) {
                 $builtDataTypes[] = $propertyType;
                 $fullyQualifiedName = $this->getFullyQualifiedNameForType($propertyType);
 
-                $dataType = ltrim($property['data_type'], '\\');
+                $dataType = ltrim($property[self::ACTOR_PROPERTY_KEY_DATA_TYPE], '\\');
                 $dataType = str_replace('Interface', '', $dataType);
 
                 $replacement .= sprintf(
@@ -61,7 +65,7 @@ class BuilderServiceFile implements AnnotationProcessorInterface
 
     protected function isPropertyComplexObject(string $type) : bool
     {
-        return strpos($type, self::NEIGHBORHOODS_NAMESPACE) === 0;
+        return strpos($type,  '\\' . $this->getAnnotationProcessorContext()->getStaticContextRecord()[self::STATIC_CONTEXT_RECORD_KEY_VENDOR]) === 0;
     }
 
     /**

--- a/src/AnnotationProcessor/Actor/RepositoryInsertElementMethod.php
+++ b/src/AnnotationProcessor/Actor/RepositoryInsertElementMethod.php
@@ -12,7 +12,13 @@ class RepositoryInsertElementMethod implements AnnotationProcessorInterface
 
     public const KEY_PROPERTIES = 'properties';
 
-    protected const NEIGHBORHOODS_NAMESPACE = '\\Neighborhoods\\';
+    public const STATIC_CONTEXT_RECORD_KEY_VENDOR = 'vendor';
+
+    public const STATIC_CONTEXT_RECORD_KEY_PROPERTIES = 'properties';
+    public const STATIC_CONTEXT_RECORD_KEY_DATA_TYPE = 'data_type';
+    public const STATIC_CONTEXT_RECORD_KEY_NULLABLE = 'nullable';
+    public const STATIC_CONTEXT_RECORD_KEY_CREATED_ON_INSERT = 'created_on_insert';
+    public const STATIC_CONTEXT_RECORD_KEY_NAME = 'name';
 
     protected const CREATE_NAMED_PARAMETER_SIMPLE_PROPERTY_PATTERN = <<< EOF
      \$values[ActorInterface::PROP_%s] = 
@@ -57,19 +63,19 @@ EOF;
         $replacement = '';
 
         foreach ($properties as $property) {
-            if ($property['created_on_insert'] === false) {
-                $propertyName = $property['name'];
+            if ($property[self::STATIC_CONTEXT_RECORD_KEY_CREATED_ON_INSERT] === false) {
+                $propertyName = $property[self::STATIC_CONTEXT_RECORD_KEY_NAME];
                 $camelCasePropertyName = $this->getCamelCasePropertyName($propertyName);
 
                 $method = sprintf(
-                    $this->isPropertyComplexObject($property['data_type']) ? 
+                    $this->isPropertyComplexObject($property[self::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE]) ?
                         self::CREATE_NAMED_PARAMETER_COMPLEX_PROPERTY_PATTERN : 
                         self::CREATE_NAMED_PARAMETER_SIMPLE_PROPERTY_PATTERN,
                     strtoupper($propertyName),
                     $camelCasePropertyName
                 );
 
-                if ($property['nullable'] === true) {
+                if ($property[self::STATIC_CONTEXT_RECORD_KEY_NULLABLE] === true) {
                     $method = sprintf(
                         self::NULLABLE_PROPERTY_CONDITION_PATTERN,
                         $camelCasePropertyName,
@@ -96,6 +102,6 @@ EOF;
 
     protected function isPropertyComplexObject(string $type) : bool
     {
-        return strpos($type, self::NEIGHBORHOODS_NAMESPACE) === 0;
+        return strpos($type,  '\\' . $this->getAnnotationProcessorContext()->getStaticContextRecord()[self::STATIC_CONTEXT_RECORD_KEY_VENDOR]) === 0;
     }
 }

--- a/src/AnnotationProcessor/Actor/RepositoryJsonColumns.php
+++ b/src/AnnotationProcessor/Actor/RepositoryJsonColumns.php
@@ -10,9 +10,12 @@ class RepositoryJsonColumns implements AnnotationProcessorInterface
 {
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Repository-JsonColumns';
 
-    public const KEY_PROPERTIES = 'properties';
+    public const STATIC_CONTEXT_RECORD_KEY_PROPERTIES = 'properties';
+    public const STATIC_CONTEXT_RECORD_KEY_VENDOR = 'vendor';
 
-    protected const NEIGHBORHOODS_NAMESPACE = '\\Neighborhoods\\';
+    public const ACTOR_PROPERTY_KEY_DATA_TYPE = 'data_type';
+    public const ACTOR_PROPERTY_KEY_NAME = 'name';
+
     protected const JSON_COLUMN_ARRAY_ITEM_PATTERN = "\t\tActorInterface::PROP_%s,\n";
 
     protected $context;
@@ -38,9 +41,9 @@ class RepositoryJsonColumns implements AnnotationProcessorInterface
     {
         $replacement = '';
 
-        foreach ($this->getAnnotationProcessorContext()->getStaticContextRecord()[self::KEY_PROPERTIES] as $property) {
-            if ($this->isPropertyJsonField($property['data_type'])) {
-                $replacement .= sprintf(self::JSON_COLUMN_ARRAY_ITEM_PATTERN, strtoupper($property['name']));
+        foreach ($this->getAnnotationProcessorContext()->getStaticContextRecord()[self::STATIC_CONTEXT_RECORD_KEY_PROPERTIES] as $property) {
+            if ($this->isPropertyJsonField($property[self::ACTOR_PROPERTY_KEY_DATA_TYPE])) {
+                $replacement .= sprintf(self::JSON_COLUMN_ARRAY_ITEM_PATTERN, strtoupper($property[self::ACTOR_PROPERTY_KEY_NAME]));
             }
         }
 
@@ -49,6 +52,7 @@ class RepositoryJsonColumns implements AnnotationProcessorInterface
 
     protected function isPropertyJsonField(string $type) : bool
     {
-        return ($type === 'array') || (strpos($type, self::NEIGHBORHOODS_NAMESPACE) === 0);
+        return ($type === 'array')
+            || strpos($type, '\\' . $this->getAnnotationProcessorContext()->getStaticContextRecord()[self::STATIC_CONTEXT_RECORD_KEY_VENDOR]) === 0;
     }
 }

--- a/src/AnnotationProcessor/Actor/RepositoryUpdateElementMethod.php
+++ b/src/AnnotationProcessor/Actor/RepositoryUpdateElementMethod.php
@@ -12,7 +12,13 @@ class RepositoryUpdateElementMethod implements AnnotationProcessorInterface
 
     public const KEY_PROPERTIES = 'properties';
 
-    protected const NEIGHBORHOODS_NAMESPACE = '\\Neighborhoods\\';
+    public const STATIC_CONTEXT_RECORD_KEY_VENDOR = 'vendor';
+
+    public const STATIC_CONTEXT_RECORD_KEY_PROPERTIES = 'properties';
+    public const STATIC_CONTEXT_RECORD_KEY_DATA_TYPE = 'data_type';
+    public const STATIC_CONTEXT_RECORD_KEY_NULLABLE = 'nullable';
+    public const STATIC_CONTEXT_RECORD_KEY_CREATED_ON_INSERT = 'created_on_insert';
+    public const STATIC_CONTEXT_RECORD_KEY_NAME = 'name';
 
     protected const CREATE_NAMED_PARAMETER_SIMPLE_PROPERTY_PATTERN = <<< EOF
      \$queryBuilder->set(ActorInterface::PROP_%s, 
@@ -21,7 +27,7 @@ EOF;
 
     protected const CREATE_NAMED_PARAMETER_COMPLEX_PROPERTY_PATTERN = <<< EOF
      \$queryBuilder->set(ActorInterface::PROP_%s, 
-            \$queryBuilder->createNamedParameter(json_encode(\$Actor->get%s()));
+            \$queryBuilder->createNamedParameter(json_encode(\$Actor->get%s())));
 EOF;
 
     protected const NULLABLE_PROPERTY_CONDITION_PATTERN = <<< EOF
@@ -57,22 +63,22 @@ EOF;
         $replacement = '';
 
         foreach ($properties as $property) {
-            if ($property['created_on_insert'] === true) {
+            if ($property[self::STATIC_CONTEXT_RECORD_KEY_CREATED_ON_INSERT] === true) {
                 continue;
             }
 
-            $propertyName = $property['name'];
+            $propertyName = $property[self::STATIC_CONTEXT_RECORD_KEY_NAME];
             $camelCasePropertyName = $this->getCamelCasePropertyName($propertyName);
 
             $method = sprintf(
-                $this->isPropertyComplexObject($property['data_type']) ?
+                $this->isPropertyComplexObject($property[self::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE]) ?
                     self::CREATE_NAMED_PARAMETER_COMPLEX_PROPERTY_PATTERN :
                     self::CREATE_NAMED_PARAMETER_SIMPLE_PROPERTY_PATTERN,
                 strtoupper($propertyName),
                 $camelCasePropertyName
             );
 
-            if ($property['nullable'] === true) {
+            if ($property[self::STATIC_CONTEXT_RECORD_KEY_NULLABLE] === true) {
                 $method = sprintf(
                     self::NULLABLE_PROPERTY_CONDITION_PATTERN,
                     $camelCasePropertyName,
@@ -98,6 +104,6 @@ EOF;
 
     protected function isPropertyComplexObject(string $type) : bool
     {
-        return strpos($type, self::NEIGHBORHOODS_NAMESPACE) === 0;
+        return strpos($type,  '\\' . $this->getAnnotationProcessorContext()->getStaticContextRecord()[self::STATIC_CONTEXT_RECORD_KEY_VENDOR]) === 0;
     }
 }

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Builder/BuildForInsertMethod/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Builder/BuildForInsertMethod/Builder.php
@@ -6,6 +6,7 @@ namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Act
 use Neighborhoods\Prefab\BuildConfigurationInterface;
 use Neighborhoods\Prefab\DaoPropertyInterface;
 use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\BuilderInterface;
+use Neighborhoods\Prefab\AnnotationProcessor;
 
 class Builder implements BuilderInterface
 {
@@ -19,13 +20,14 @@ class Builder implements BuilderInterface
         /** @var DaoPropertyInterface $daoProperty */
         foreach ($this->getBuildConfiguration()->getDaoProperties() as $daoProperty) {
             $propertyArray[$daoProperty->getName()] = [
-                'nullable' => $daoProperty->getNullable(),
-                'data_type' => $daoProperty->getDataType(),
-                'created_on_insert' => $daoProperty->getCreatedOnInsert(),
+                AnnotationProcessor\Actor\BuilderBuildForInsertMethod::ACTOR_PROPERTY_KEY_NULLABLE => $daoProperty->getNullable(),
+                AnnotationProcessor\Actor\BuilderBuildForInsertMethod::ACTOR_PROPERTY_KEY_DATA_TYPE => $daoProperty->getDataType(),
+                AnnotationProcessor\Actor\BuilderBuildForInsertMethod::ACTOR_PROPERTY_KEY_CREATED_ON_INSERT => $daoProperty->getCreatedOnInsert(),
             ];
         }
 
-        $staticContextRecord['properties'] = $propertyArray;
+        $staticContextRecord[AnnotationProcessor\Actor\BuilderBuildForInsertMethod::STATIC_CONTEXT_RECORD_KEY_PROPERTIES] = $propertyArray;
+        $staticContextRecord[AnnotationProcessor\Actor\BuilderBuildForInsertMethod::STATIC_CONTEXT_RECORD_KEY_VENDOR] = $this->getBuildConfiguration()->getVendorName();
 
         return $staticContextRecord;
     }

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Builder/BuildMethod/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Builder/BuildMethod/Builder.php
@@ -6,6 +6,7 @@ namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Act
 use Neighborhoods\Prefab\BuildConfigurationInterface;
 use Neighborhoods\Prefab\DaoPropertyInterface;
 use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\BuilderInterface;
+use Neighborhoods\Prefab\AnnotationProcessor;
 
 class Builder implements BuilderInterface
 {
@@ -19,13 +20,14 @@ class Builder implements BuilderInterface
         /** @var DaoPropertyInterface $daoProperty */
         foreach ($this->getBuildConfiguration()->getDaoProperties() as $daoProperty) {
             $propertyArray[$daoProperty->getName()] = [
-                'nullable' => $daoProperty->getNullable(),
-                'data_type' => $daoProperty->getDataType(),
-                'created_on_insert' => $daoProperty->getCreatedOnInsert(),
+                AnnotationProcessor\Actor\Builder::ACTOR_PROPERTY_KEY_NULLABLE => $daoProperty->getNullable(),
+                AnnotationProcessor\Actor\Builder::ACTOR_PROPERTY_KEY_DATA_TYPE => $daoProperty->getDataType(),
+                AnnotationProcessor\Actor\Builder::ACTOR_PROPERTY_KEY_CREATED_ON_INSERT => $daoProperty->getCreatedOnInsert(),
             ];
         }
 
-        $staticContextRecord['properties'] = $propertyArray;
+        $staticContextRecord[AnnotationProcessor\Actor\Builder::STATIC_CONTEXT_RECORD_KEY_PROPERTIES] = $propertyArray;
+        $staticContextRecord[AnnotationProcessor\Actor\Builder::STATIC_CONTEXT_RECORD_KEY_VENDOR] = $this->getBuildConfiguration()->getVendorName();
 
         return $staticContextRecord;
     }

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Builder/BuilderFactoryAwareTraits/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Builder/BuilderFactoryAwareTraits/Builder.php
@@ -6,6 +6,7 @@ namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Act
 use Neighborhoods\Prefab\BuildConfigurationInterface;
 use Neighborhoods\Prefab\DaoPropertyInterface;
 use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\BuilderInterface;
+use Neighborhoods\Prefab\AnnotationProcessor;
 
 class Builder implements BuilderInterface
 {
@@ -19,13 +20,14 @@ class Builder implements BuilderInterface
         /** @var DaoPropertyInterface $daoProperty */
         foreach ($this->getBuildConfiguration()->getDaoProperties() as $daoProperty) {
             $propertyArray[$daoProperty->getName()] = [
-                'nullable' => $daoProperty->getNullable(),
-                'data_type' => $daoProperty->getDataType(),
-                'created_on_insert' => $daoProperty->getCreatedOnInsert(),
+                AnnotationProcessor\Actor\BuilderFactoryTrait::ACTOR_PROPERTY_KEY_NULLABLE => $daoProperty->getNullable(),
+                AnnotationProcessor\Actor\BuilderFactoryTrait::ACTOR_PROPERTY_KEY_DATA_TYPE => $daoProperty->getDataType(),
+                AnnotationProcessor\Actor\BuilderFactoryTrait::ACTOR_PROPERTY_KEY_CREATED_ON_INSERT => $daoProperty->getCreatedOnInsert(),
             ];
         }
 
-        $staticContextRecord['properties'] = $propertyArray;
+        $staticContextRecord[AnnotationProcessor\Actor\BuilderFactoryTrait::STATIC_CONTEXT_RECORD_KEY_PROPERTIES] = $propertyArray;
+        $staticContextRecord[AnnotationProcessor\Actor\BuilderFactoryTrait::STATIC_CONTEXT_RECORD_KEY_VENDOR] = $this->getBuildConfiguration()->getVendorName();
 
         return $staticContextRecord;
     }

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/BuilderServiceFile/FactorySetters/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/BuilderServiceFile/FactorySetters/Builder.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Map\Repository\JsonColumns;
+namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\BuilderServiceFile\FactorySetters;
 
 use Neighborhoods\Prefab\BuildConfigurationInterface;
 use Neighborhoods\Prefab\DaoPropertyInterface;
@@ -14,21 +14,20 @@ class Builder implements BuilderInterface
 
     public function build() : array
     {
-        $buildConfiguration = $this->getBuildConfiguration();
         $staticContextRecord = [];
+        $propertyArray = [];
 
-        /** @var DaoPropertyInterface $property */
-        foreach ($buildConfiguration->getDaoProperties() as $property) {
-            $staticContextRecord[] = [
-                AnnotationProcessor\Actor\RepositoryJsonColumns::ACTOR_PROPERTY_KEY_NAME => $property->getName(),
-                AnnotationProcessor\Actor\RepositoryJsonColumns::ACTOR_PROPERTY_KEY_DATA_TYPE => $property->getDataType()
+        /** @var DaoPropertyInterface $daoProperty */
+        foreach ($this->getBuildConfiguration()->getDaoProperties() as $daoProperty) {
+            $propertyArray[$daoProperty->getName()] = [
+                AnnotationProcessor\Actor\BuilderServiceFile::ACTOR_PROPERTY_KEY_DATA_TYPE => $daoProperty->getDataType(),
             ];
         }
 
-        return [
-            AnnotationProcessor\Actor\RepositoryJsonColumns::STATIC_CONTEXT_RECORD_KEY_PROPERTIES => $staticContextRecord,
-            AnnotationProcessor\Actor\RepositoryJsonColumns::STATIC_CONTEXT_RECORD_KEY_VENDOR => $this->getBuildConfiguration()->getVendorName(),
-        ];
+        $staticContextRecord[AnnotationProcessor\Actor\BuilderServiceFile::STATIC_CONTEXT_RECORD_KEY_PROPERTIES] = $propertyArray;
+        $staticContextRecord[AnnotationProcessor\Actor\BuilderServiceFile::STATIC_CONTEXT_RECORD_KEY_VENDOR] = $this->getBuildConfiguration()->getVendorName();
+
+        return $staticContextRecord;
     }
 
     protected function getBuildConfiguration() : BuildConfigurationInterface

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Map/Repository/RepositoryInsertElementMethod/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Map/Repository/RepositoryInsertElementMethod/Builder.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Map\Repository\RepositoryInsertElementMethod;
 
+use Neighborhoods\Prefab\AnnotationProcessor\Actor\RepositoryInsertElementMethod;
 use Neighborhoods\Prefab\BuildConfigurationInterface;
 use Neighborhoods\Prefab\DaoPropertyInterface;
 use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\BuilderInterface;
@@ -19,14 +20,17 @@ class Builder implements BuilderInterface
         /** @var DaoPropertyInterface $property */
         foreach ($buildConfiguration->getDaoProperties() as $property) {
             $staticContextRecord[] = [
-                'name' => $property->getName(),
-                'data_type' => $property->getDataType(),
-                'created_on_insert' => $property->getCreatedOnInsert(),
-                'nullable' => $property->getNullable(),
+                RepositoryInsertElementMethod::STATIC_CONTEXT_RECORD_KEY_NAME => $property->getName(),
+                RepositoryInsertElementMethod::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE => $property->getDataType(),
+                RepositoryInsertElementMethod::STATIC_CONTEXT_RECORD_KEY_NULLABLE => $property->getNullable(),
+                RepositoryInsertElementMethod::STATIC_CONTEXT_RECORD_KEY_CREATED_ON_INSERT => $property->getCreatedOnInsert()
             ];
         }
 
-        return ['properties' => $staticContextRecord];
+        return [
+            RepositoryInsertElementMethod::STATIC_CONTEXT_RECORD_KEY_PROPERTIES => $staticContextRecord,
+            RepositoryInsertElementMethod::STATIC_CONTEXT_RECORD_KEY_VENDOR => $this->getBuildConfiguration()->getVendorName()
+        ];
     }
 
     protected function getBuildConfiguration() : BuildConfigurationInterface

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Map/Repository/RepositoryUpdateElementMethod/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Map/Repository/RepositoryUpdateElementMethod/Builder.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Map\Repository\RepositoryUpdateElementMethod;
 
+use Neighborhoods\Prefab\AnnotationProcessor\Actor\RepositoryUpdateElementMethod;
 use Neighborhoods\Prefab\BuildConfigurationInterface;
 use Neighborhoods\Prefab\DaoPropertyInterface;
 use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\BuilderInterface;
@@ -19,14 +20,17 @@ class Builder implements BuilderInterface
         /** @var DaoPropertyInterface $property */
         foreach ($buildConfiguration->getDaoProperties() as $property) {
             $staticContextRecord[] = [
-                'name' => $property->getName(),
-                'data_type' => $property->getDataType(),
-                'nullable' => $property->getNullable(),
-                'created_on_insert' => $property->getCreatedOnInsert()
+                RepositoryUpdateElementMethod::STATIC_CONTEXT_RECORD_KEY_NAME => $property->getName(),
+                RepositoryUpdateElementMethod::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE => $property->getDataType(),
+                RepositoryUpdateElementMethod::STATIC_CONTEXT_RECORD_KEY_NULLABLE => $property->getNullable(),
+                RepositoryUpdateElementMethod::STATIC_CONTEXT_RECORD_KEY_CREATED_ON_INSERT => $property->getCreatedOnInsert()
             ];
         }
 
-        return ['properties' => $staticContextRecord];
+        return [
+            RepositoryUpdateElementMethod::STATIC_CONTEXT_RECORD_KEY_PROPERTIES => $staticContextRecord,
+            RepositoryUpdateElementMethod::STATIC_CONTEXT_RECORD_KEY_VENDOR => $this->getBuildConfiguration()->getVendorName()
+        ];
     }
 
     protected function getBuildConfiguration() : BuildConfigurationInterface

--- a/src/Bradfab/Template/RepositoryActor.php
+++ b/src/Bradfab/Template/RepositoryActor.php
@@ -59,7 +59,7 @@ class RepositoryActor implements RepositoryActorInterface
                     RepositoryJsonColumns::ANNOTATION_PROCESSOR_KEY => [
                         Template::KEY_PROCESSOR_FULLY_QUALIFIED_CLASSNAME => '\\' . RepositoryJsonColumns::class,
                         Template::KEY_STATIC_CONTEXT_RECORD => [
-                            RepositoryJsonColumns::KEY_PROPERTIES => $propertyArray,
+                            RepositoryJsonColumns::STATIC_CONTEXT_RECORD_KEY_PROPERTIES => $propertyArray,
                         ],
                     ],
                     RepositoryInsertElementMethod::ANNOTATION_PROCESSOR_KEY => [


### PR DESCRIPTION
- Added a vendor key to all static context record builders that need to check for complex objects
- Add missing builder service file static context record builder
- Use vendor key rather than assuming a vendor of `Neighborhoods` in annotation processors
- Replaced strings with named constants