### PR TITLE
Make Redis optional

### DIFF
--- a/http/fab/Prefab5/Redis/Factory.php
+++ b/http/fab/Prefab5/Redis/Factory.php
@@ -22,12 +22,14 @@ class Factory implements FactoryInterface
         return $redis;
     }
 
-    public function setPort(int $port): FactoryInterface
+    public function setPort(?int $port): FactoryInterface
     {
-        if ($this->port === null) {
+        if ($port !== null) {
+            if ($this->port !== null) {
+                throw new \LogicException('Port is already set.');
+            }
+
             $this->port = $port;
-        } else {
-            throw new \LogicException('Port is already set.');
         }
 
         return $this;
@@ -42,12 +44,14 @@ class Factory implements FactoryInterface
         return $this->port;
     }
 
-    public function setHost(string $host): FactoryInterface
+    public function setHost(?string $host): FactoryInterface
     {
-        if ($this->host === null) {
+        if ($host !== null) {
+            if ($this->host !== null) {
+                throw new \LogicException('Host is already set.');
+            }
+
             $this->host = $host;
-        } else {
-            throw new \LogicException('Host is already set.');
         }
 
         return $this;

--- a/http/fab/Prefab5/Redis/Factory.service.yml
+++ b/http/fab/Prefab5/Redis/Factory.service.yml
@@ -1,6 +1,8 @@
 parameters:
-  ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\Redis\FactoryInterface.redis_port: '%env(REDIS_PORT)%'
-  ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\Redis\FactoryInterface.redis_host: '%env(REDIS_HOST)%'
+  redis_port_default_value: null
+  redis_host_default_value: null
+  ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\Redis\FactoryInterface.redis_port: '%env(default:redis_port_default_value:REDIS_PORT)%'
+  ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\Redis\FactoryInterface.redis_host: '%env(default:redis_host_default_value:REDIS_HOST)%'
 services:
   ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\Redis\FactoryInterface:
     class: ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\Redis\Factory

--- a/http/fab/Prefab5/Redis/Factory.service.yml
+++ b/http/fab/Prefab5/Redis/Factory.service.yml
@@ -9,6 +9,6 @@ services:
     public: false
     shared: true
     calls:
-      - [addOption, [!php/const \Redis::OPT_READ_TIMEOUT, '-1']]
+      - [addOption, [!php/const \ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\Redis\FactoryInterface::REDIS_OPT_READ_TIMEOUT, '-1']]
       - [setHost, ['%ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\Redis\FactoryInterface.redis_host%']]
       - [setPort, ['%ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\Redis\FactoryInterface.redis_port%']]

--- a/http/fab/Prefab5/Redis/FactoryInterface.php
+++ b/http/fab/Prefab5/Redis/FactoryInterface.php
@@ -8,6 +8,8 @@ interface FactoryInterface
     public const PROP_HOST = 'host';
     public const PROP_PORT = 'port';
 
+    public const REDIS_OPT_READ_TIMEOUT = 3;
+
     public function create(): \Redis;
 
     public function setPort(int $port): FactoryInterface;


### PR DESCRIPTION
Prefab doesn't actually use Redis so we shouldn't force users to have it installed.