### PR TITLE
Non-OSX filesystems are case-sensitive and will result in errors

### DIFF
--- a/src/Actor.buphalo.v1.fabrication.yml
+++ b/src/Actor.buphalo.v1.fabrication.yml
@@ -26,7 +26,7 @@ actors:
           - name: templatePath
             type: string
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -34,9 +34,9 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Map/AwareTrait.php:
-    template: PrimaryActorName/Map/Awaretrait.php
+    template: PrimaryActorName/Map/AwareTrait.php
   <PrimaryActorName>/Map/Factory.php:
     template: PrimaryActorName/Map/Factory.php
   <PrimaryActorName>/Map/Factory/AwareTrait.php:

--- a/src/AnnotationProcessorRecord.buphalo.v1.fabrication.yml
+++ b/src/AnnotationProcessorRecord.buphalo.v1.fabrication.yml
@@ -26,7 +26,7 @@ actors:
           - name: annotationProcessorKey
             type: string
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -34,7 +34,7 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Map/Factory.php:
     template: PrimaryActorName/Map/Factory.php
   <PrimaryActorName>/Map/Factory.service.yml:

--- a/src/AnnotationProcessorRecord/StaticContextRecord.buphalo.v1.fabrication.yml
+++ b/src/AnnotationProcessorRecord/StaticContextRecord.buphalo.v1.fabrication.yml
@@ -20,7 +20,7 @@ actors:
           - name: staticContextRecord
             type: array
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -28,7 +28,7 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Map/Factory.php:
     template: PrimaryActorName/Map/Factory.php
   <PrimaryActorName>/Map/Factory.service.yml:

--- a/src/BuildConfiguration.buphalo.v1.fabrication.yml
+++ b/src/BuildConfiguration.buphalo.v1.fabrication.yml
@@ -58,7 +58,7 @@ actors:
         - name: constantMap
           type: \Neighborhoods\Prefab\Constant\MapInterface
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -66,7 +66,7 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Map/Factory.php:
     template: PrimaryActorName/Map/Factory.php
   <PrimaryActorName>/Map/Factory.service.yml:

--- a/src/Constant.buphalo.v1.fabrication.yml
+++ b/src/Constant.buphalo.v1.fabrication.yml
@@ -27,7 +27,7 @@ actors:
               type: string
               record_key: value
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -35,9 +35,9 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Map/AwareTrait.php:
-    template: PrimaryActorName/Map/Awaretrait.php
+    template: PrimaryActorName/Map/AwareTrait.php
   <PrimaryActorName>/Map/Factory.php:
     template: PrimaryActorName/Map/Factory.php
   <PrimaryActorName>/Map/Factory/AwareTrait.php:

--- a/src/DaoProperty.buphalo.v1.fabrication.yml
+++ b/src/DaoProperty.buphalo.v1.fabrication.yml
@@ -34,7 +34,7 @@ actors:
           - name: createdOnInsert
             type: bool
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -42,7 +42,7 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Map/Factory.php:
     template: PrimaryActorName/Map/Factory.php
   <PrimaryActorName>/Map/Factory.service.yml:

--- a/src/FabricationSpecification.buphalo.v1.fabrication.yml
+++ b/src/FabricationSpecification.buphalo.v1.fabrication.yml
@@ -18,7 +18,7 @@ actors:
           - name: actorMap
             type: \Neighborhoods\Prefab\Actor\MapInterface
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -26,7 +26,7 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Map/Factory.php:
     template: PrimaryActorName/Map/Factory.php
   <PrimaryActorName>/Map/Factory.service.yml:

--- a/src/FabricationSpecification/AllSupportingActors.buphalo.v1.fabrication.yml
+++ b/src/FabricationSpecification/AllSupportingActors.buphalo.v1.fabrication.yml
@@ -1,6 +1,6 @@
 actors:
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -8,7 +8,7 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Builder/Factory.service.yml:
     template: PrimaryActorName/Builder/Factory.service.yml
   <PrimaryActorName>/Builder/Factory.php:

--- a/src/FabricationSpecification/Collection.buphalo.v1.fabrication.yml
+++ b/src/FabricationSpecification/Collection.buphalo.v1.fabrication.yml
@@ -1,6 +1,6 @@
 actors:
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -8,7 +8,7 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Builder/Factory.service.yml:
     template: PrimaryActorName/Builder/Factory.service.yml
   <PrimaryActorName>/Builder/Factory.php:

--- a/src/FabricationSpecification/Minimal.buphalo.v1.fabrication.yml
+++ b/src/FabricationSpecification/Minimal.buphalo.v1.fabrication.yml
@@ -1,6 +1,6 @@
 actors:
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -8,7 +8,7 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Builder/Factory.service.yml:
     template: PrimaryActorName/Builder/Factory.service.yml
   <PrimaryActorName>/Builder/Factory.php:

--- a/src/FabricationSpecification/Writer.buphalo.v1.fabrication.yml
+++ b/src/FabricationSpecification/Writer.buphalo.v1.fabrication.yml
@@ -1,6 +1,6 @@
 actors:
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -8,4 +8,4 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php

--- a/src/TokenReplacer.buphalo.v1.fabrication.yml
+++ b/src/TokenReplacer.buphalo.v1.fabrication.yml
@@ -2,7 +2,7 @@ actors:
   <PrimaryActorName>.service.yml:
     template: PrimaryActorName.service.yml
   <PrimaryActorName>/AwareTrait.php:
-    template: PrimaryActorName/Awaretrait.php
+    template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:
     template: PrimaryActorName/Factory.php
   <PrimaryActorName>/Factory.service.yml:
@@ -10,4 +10,4 @@ actors:
   <PrimaryActorName>/FactoryInterface.php:
     template: PrimaryActorName/FactoryInterface.php
   <PrimaryActorName>/Factory/AwareTrait.php:
-    template: PrimaryActorName/Factory/Awaretrait.php
+    template: PrimaryActorName/Factory/AwareTrait.php


### PR DESCRIPTION
I used these as example files to start building some Buphalo stuff and ran into issues with `Awaretrait.php` not being found due to the case-sensitive filesystem that Jenkins runs.

Harsh was wise enough to recognize the pattern that both Neal and I had the same mistake, and thus likely copied it from the same place.

