### PR TITLE
HOTFIX | Prevent unintended 0-offset

### DIFF
--- a/http/fab/Prefab5/SearchCriteria/Doctrine/DBAL/Query/QueryBuilder/Visitor.php
+++ b/http/fab/Prefab5/SearchCriteria/Doctrine/DBAL/Query/QueryBuilder/Visitor.php
@@ -174,6 +174,10 @@ class Visitor implements VisitorInterface
 
     public function setCurrentPage(int $currentPage): SearchCriteria\VisitorInterface
     {
+        if ($this->getQueryBuilder()->getMaxResults() === null) {
+            throw new \LogicException('You must call setPageSize before you call setCurrentPage.');
+        }
+
         $this->getQueryBuilder()->setFirstResult($this->getQueryBuilder()->getMaxResults() * $currentPage);
 
         return $this;


### PR DESCRIPTION
Because this uses the visitor pattern instead of a builder pattern,
and because `setCurrentPage` relies on `QueryBuilder::getMaxResults()`
already being set, we MUST throw an exception if it hasn't been.

Otherwise what happens is that `getMaxResults` will return `null`
and `null * $currentPage` returns 0.