### PR TITLE
JSON SearchCriteria did not behave as expected, limit what is returned

### DIFF
--- a/http/fab/Prefab5/SearchCriteria.php
+++ b/http/fab/Prefab5/SearchCriteria.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5;
 
+use ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\SearchCriteria\BuilderInterface;
 use ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\SearchCriteria\FilterInterface;
 use ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\SearchCriteria\SortOrder;
 use ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\SearchCriteria\Filter;
@@ -31,9 +32,27 @@ class SearchCriteria implements SearchCriteriaInterface
     /** @var int */
     protected $currentPage;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
-        return get_object_vars($this);
+        $json = [];
+
+        if (null !== $this->filters) {
+            $json[BuilderInterface::FILTERS] = $this->getFilters();
+        }
+
+        if (null !== $this->sortOrders) {
+            $json[BuilderInterface::SORT_ORDER] = $this->getSortOrders();
+        }
+
+        if (null !== $this->pageSize) {
+            $json[BuilderInterface::PAGE_SIZE] = $this->pageSize;
+        }
+
+        if (null !== $this->currentPage) {
+            $json[BuilderInterface::CURRENT_PAGE] = $this->currentPage;
+        }
+
+        return array_filter($json);
     }
 
     public function addFilter(FilterInterface $filter): SearchCriteriaInterface


### PR DESCRIPTION
I want to make HTTP POST requests using the details used within a SearchCriteria object.

Current JSON serialization yields:
```
{
  "filters": {
    "0": {
      "field": "listing_status",
      "values": [
        "active"
      ],
      "condition": "in",
      "glue": "and"
    },
    "1": {
      "field": "coordinates",
      "values": [
        "MULTIPOLYGON(((-87.694741934538 41.961282664914,-87.673966884613 41.961525492645,-87.67377326265 41.954229910643,-87.67402086407 41.954228539285,-87.67382003367 41.946942720005,-87.696190327406 41.946698839239,-87.696824669838 41.950278655877,-87.694480419159 41.954004882833,-87.694439515472 41.957851315409,-87.694741934538 41.961282664914)))"
      ],
      "condition": "st_within",
      "glue": "and"
    }
  },
  "sortOrders": {
    "0": {
      "field": "imported_at",
      "direction": "DESC"
    }
  },
  "visitors": {
    "Neighborhoods\\AreaServiceReplacement\\Prefab5\\SearchCriteria\\Doctrine\\DBAL\\Query\\QueryBuilder\\VisitorInterface": {}
  },
  "pageSize": 200,
  "currentPage": null,
  "NeighborhoodsAreaServiceReplacementSearchCriteriaFilterMapFactory": {},
  "NeighborhoodsAreaServiceReplacementSearchCriteriaSortOrderMapFactory": {},
  "NeighborhoodsAreaServiceReplacementSearchCriteriaVisitorMapFactory": {},
  "NeighborhoodsAreaServiceReplacementSearchCriteriaDoctrineDBALQueryQueryBuilderVisitorFactory": {}
}
```

I feel that no one will need the serialized version of the MapFactory objects so I want to eliminate them.

The goal is to serialize only the things that would need to be passed into the `body` of an HTTP POST request.