### PR TITLE
Extracted building of Zend Expressive into dedicated class

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -39,6 +39,7 @@ $cacheHandler = (new \Neighborhoods\DependencyInjectionContainerBuilderComponent
 $container = (new \Neighborhoods\DependencyInjectionContainerBuilderComponent\TinyContainerBuilder())
     ->setContainerBuilder(new \Symfony\Component\DependencyInjection\ContainerBuilder())
     ->setRootPath($rootDirectory)
+    ->setCacheHandler($cacheHandler)
     ->addSourcePath('src/ProductComponent')
     ->addSourcePath('fab/ProductComponent')
     ->addSourcePath('vendor/neighborhoods/throwable-diagnostic-component/src')
@@ -51,7 +52,47 @@ $container = (new \Neighborhoods\DependencyInjectionContainerBuilderComponent\Ti
 
 $instance = $container->get(SomeInterface::class);
 ```
- * Building zend expressive had been deprecated and has been removed, but if you need it you can find it in the [ContainerBuilder](https://github.com/neighborhoods/Prefab/blob/8.x/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder.php).
+
+* `TinyContainerBuilder` doesn't know about Zend Expressive. If you need to build the Zend Expressive DI YAML use [ZendExpressiveServicesBuilder](https://github.com/neighborhoods/Prefab/blob/8.x/http/fab/Prefab5/HTTPBuildableDirectoryMap/ZendExpressiveServicesBuilder.php). To avoid repeating regeneration of the file although the container is cached, use DICBC `CacheHandler`'s `hasInCache()` and `getFromCache()` methods before using `ZendExpressiveServicesBuilder`.
+
+Prefab 7
+
+``` php
+$proteanContainerBuilder = new Prefab5\Protean\Container\Builder();
+$proteanContainerBuilder->setContainerName('ContainerName');
+$proteanContainerBuilder->getFilesystemProperties()->setRootDirectoryPath(realpath(dirname(__DIR__)));
+$proteanContainerBuilder->setCanBuildZendExpressive(true);
+// Further builder configuration
+return $proteanContainerBuilder->build();
+```
+
+Prefab 8
+
+``` php
+$rootDirectory = realpath(dirname(__DIR__));
+$cacheHandler = (new \Neighborhoods\DependencyInjectionContainerBuilderComponent\SymfonyConfigCacheHandler\Builder())
+    ->setName('ContainerName')
+    ->setCacheDirPath($rootDirectory . '/data/cache')
+    ->setDebug(false)
+    ->build();
+
+if ($cacheHandler->hasInCache()) {
+    return $cacheHandler->getFromCache();
+}
+
+$filesystemProperties = new ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildableDirectoryMap\FilesystemProperties();
+$filesystemProperties->setRootDirectoryPath($rootDirectory);
+$zendExpressiveServicesBuilder = new ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildableDirectoryMap\ZendExpressiveServicesBuilder();
+$zendExpressiveServicesBuilder->setHTTPBuildableDirectoryMapFilesystemProperties($filesystemProperties);
+$zendPath = $zendExpressiveServicesBuilder->buildDIYAMLFile();
+return (new \Neighborhoods\DependencyInjectionContainerBuilderComponent\TinyContainerBuilder())
+    ->setContainerBuilder(new \Symfony\Component\DependencyInjection\ContainerBuilder())
+    ->setCacheHandler($cacheHandler) // The container will be cached
+    ->setRootPath($rootDirectory)
+    ->addSourcePath($zendPath)
+// Further builder configuration
+    ->build();
+```
  * `Neighborhoods\Product\Prefab5\Protean\Container\Builder\FilesystemProperties` and the interface were moved to the `Neighborhoods\Product\Prefab5\HTTPBuildableDirectoryMap` namespace. It is no longer aware of the Protean Container Builder and lost the `getSymfonyContainerFilePath()` method. You **probably don't** use this class.
  * `Neighborhoods\Product\Prefab5\Protean\Container\Builder\DiscoverableDirectories` and the interface were moved to the `Neighborhoods\Product\Prefab5\HTTPBuildableDirectoryMap` namespace. It lost all business logic and is converted to a plain data access object. You might use this class indirectly, e.g. `$proteanContainerBuilder->getDiscoverableDirectories()`. After replacing Protean Container Builder as shown above you shouldn't need it anymore.
  * `Neighborhoods\Product\Prefab5\WelcomeBaskets` and the interface have been removed. It is **unlikely** that you use them directly.

--- a/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder.php
+++ b/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder.php
@@ -77,7 +77,7 @@ class ContainerBuilder implements ContainerBuilderInterface
         return $containerBuilder->build();
     }
 
-    public function buildZendExpressive(FilesystemPropertiesInterface $filesystemProperties): string
+    protected function buildZendExpressive(FilesystemPropertiesInterface $filesystemProperties): string
     {
         $servicesBuilder = new ZendExpressiveServicesBuilder();
         $servicesBuilder->setHTTPBuildableDirectoryMapFilesystemProperties($filesystemProperties);

--- a/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder.php
+++ b/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder.php
@@ -11,7 +11,6 @@ use ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefa
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\InlineServiceDefinitionsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
-use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
 use Symfony\Component\Filesystem\Filesystem;
 use Zend\Expressive\Application;
 
@@ -80,19 +79,9 @@ class ContainerBuilder implements ContainerBuilderInterface
 
     public function buildZendExpressive(FilesystemPropertiesInterface $filesystemProperties): string
     {
-        $currentWorkingDirectory = getcwd();
-        chdir($filesystemProperties->getRootDirectoryPath());
-        /** @noinspection PhpIncludeInspection */
-        $zendContainerBuilder = require $filesystemProperties->getZendConfigContainerFilePath();
-        $applicationServiceDefinition = $zendContainerBuilder->findDefinition(Application::class);
-        /** @noinspection PhpIncludeInspection */
-        (require $filesystemProperties->getPipelineFilePath())($applicationServiceDefinition);
-        file_put_contents(
-            $filesystemProperties->getExpressiveDIYAMLFilePath(),
-            (new YamlDumper($zendContainerBuilder))->dump()
-        );
-        chdir($currentWorkingDirectory);
-        return $filesystemProperties->getZendCacheDirectoryPath();
+        $servicesBuilder = new ZendExpressiveServicesBuilder();
+        $servicesBuilder->setHTTPBuildableDirectoryMapFilesystemProperties($filesystemProperties);
+        return $servicesBuilder->buildDIYAMLFile();
     }
 
     protected function getFullPaths(DiscoverableDirectoriesInterface $discoverableDirectories, FilesystemPropertiesInterface $filesystemProperties): array

--- a/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder.php
+++ b/http/fab/Prefab5/HTTPBuildableDirectoryMap/ContainerBuilder.php
@@ -16,9 +16,9 @@ use Zend\Expressive\Application;
 
 class ContainerBuilder implements ContainerBuilderInterface
 {
-    protected $buildableDirectoryMap;
-    protected $directoryGroup;
-    protected $rootDirectoryPath;
+    private $buildableDirectoryMap;
+    private $directoryGroup;
+    private $rootDirectoryPath;
 
     public function build() : ContainerInterface
     {
@@ -77,14 +77,14 @@ class ContainerBuilder implements ContainerBuilderInterface
         return $containerBuilder->build();
     }
 
-    protected function buildZendExpressive(FilesystemPropertiesInterface $filesystemProperties): string
+    private function buildZendExpressive(FilesystemPropertiesInterface $filesystemProperties): string
     {
         $servicesBuilder = new ZendExpressiveServicesBuilder();
         $servicesBuilder->setHTTPBuildableDirectoryMapFilesystemProperties($filesystemProperties);
         return $servicesBuilder->buildDIYAMLFile();
     }
 
-    protected function getFullPaths(DiscoverableDirectoriesInterface $discoverableDirectories, FilesystemPropertiesInterface $filesystemProperties): array
+    private function getFullPaths(DiscoverableDirectoriesInterface $discoverableDirectories, FilesystemPropertiesInterface $filesystemProperties): array
     {
         $filesystem = new Filesystem();
         $fullPaths = [];
@@ -124,7 +124,7 @@ class ContainerBuilder implements ContainerBuilderInterface
         return $this;
     }
 
-    protected function getBuildableDirectoryMap() : array
+    private function getBuildableDirectoryMap() : array
     {
         if ($this->buildableDirectoryMap === null) {
             throw new LogicException('ContainerBuilder buildableDirectoryMap has not been set.');
@@ -132,7 +132,7 @@ class ContainerBuilder implements ContainerBuilderInterface
         return $this->buildableDirectoryMap;
     }
 
-    protected function hasBuildableDirectoryMap(): bool
+    private function hasBuildableDirectoryMap(): bool
     {
         return $this->buildableDirectoryMap !== null;
     }
@@ -163,7 +163,7 @@ class ContainerBuilder implements ContainerBuilderInterface
         return $this;
     }
 
-    protected function hasDirectoryGroup(): bool
+    private function hasDirectoryGroup(): bool
     {
         return $this->directoryGroup !== null;
     }

--- a/http/fab/Prefab5/HTTPBuildableDirectoryMap/ZendExpressiveServicesBuilder.php
+++ b/http/fab/Prefab5/HTTPBuildableDirectoryMap/ZendExpressiveServicesBuilder.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildableDirectoryMap;
+
+use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
+use Zend\Expressive\Application;
+
+class ZendExpressiveServicesBuilder implements ZendExpressiveServicesBuilderInterface
+{
+    use FilesystemProperties\AwareTrait;
+
+    public function buildDIYAMLFile(): string
+    {
+        $filesystemProperties = $this->getHTTPBuildableDirectoryMapFilesystemProperties();
+        $initialWorkingDirectory = getcwd();
+        chdir($filesystemProperties->getRootDirectoryPath());
+        /** @noinspection PhpIncludeInspection */
+        $zendContainerBuilder = require $filesystemProperties->getZendConfigContainerFilePath();
+        $applicationServiceDefinition = $zendContainerBuilder->findDefinition(Application::class);
+        /** @noinspection PhpIncludeInspection */
+        (require $filesystemProperties->getPipelineFilePath())($applicationServiceDefinition);
+        file_put_contents(
+            $filesystemProperties->getExpressiveDIYAMLFilePath(),
+            (new YamlDumper($zendContainerBuilder))->dump()
+        );
+        chdir($initialWorkingDirectory);
+        return $filesystemProperties->getZendCacheDirectoryPath();
+    }
+}

--- a/http/fab/Prefab5/HTTPBuildableDirectoryMap/ZendExpressiveServicesBuilderInterface.php
+++ b/http/fab/Prefab5/HTTPBuildableDirectoryMap/ZendExpressiveServicesBuilderInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace ReplaceThisWithTheNameOfYourVendor\ReplaceThisWithTheNameOfYourProduct\Prefab5\HTTPBuildableDirectoryMap;
+
+interface ZendExpressiveServicesBuilderInterface
+{
+    public function setHTTPBuildableDirectoryMapFilesystemProperties(FilesystemPropertiesInterface $proteanContainerBuilderFilesystemProperties);
+
+    public function buildDIYAMLFile(): string;
+}


### PR DESCRIPTION
The alpha release of Prefab 8 was tried out on Inquiry service (https://github.com/neighborhoods/InquiryService/pull/19).
Turns out it's unclear how to build the zend expressive services because the DICBC doesn't know about zend.
This PR extracts Zend Expressive building into a dedicated class.

I've tested these changes locally on PrefabFitness. It's working just fine.