### PR TITLE
HOTFIX | Ignore Errors that were marked with @

### DIFF
--- a/http/fab/Prefab5/ErrorHandler.php
+++ b/http/fab/Prefab5/ErrorHandler.php
@@ -10,7 +10,10 @@ class ErrorHandler implements ErrorHandlerInterface
         string $errorString,
         string $errorFile,
         int $errorLine
-    ): ErrorHandlerInterface {
+    ) {
+        if (!(error_reporting() & $errorNumber)) {
+            return false; /* @see https://www.php.net/manual/en/language.operators.errorcontrol.php */
+        }
         throw new \ErrorException($errorString, $errorNumber, $errorNumber, $errorFile, $errorLine);
     }
 }

--- a/http/fab/Prefab5/Symfony/Component/DependencyInjection/ErrorHandler.php
+++ b/http/fab/Prefab5/Symfony/Component/DependencyInjection/ErrorHandler.php
@@ -15,7 +15,10 @@ class ErrorHandler implements ErrorHandlerInterface
         string $errorFile,
         int $errorLine,
         array $errorContext
-    ): ErrorHandlerInterface {
+    ) {
+        if (!(error_reporting() & $errorNumber)) {
+            return false; /* @see https://www.php.net/manual/en/language.operators.errorcontrol.php */
+        }
         throw new \ErrorException($errorString, $errorNumber, $errorNumber, $errorFile, $errorLine);
     }
 }


### PR DESCRIPTION
See https://www.php.net/manual/en/language.operators.errorcontrol.php for the why and how.
Without this change, Errors that result from code called with the `@` error control prefix are still propagating up and being thrown.

Toy example with the change: https://3v4l.org/u8Kpf
Toy example without the change: https://3v4l.org/Qstv5

Related PR for [6.x](https://github.com/neighborhoods/Prefab/pull/241) and [7.x](https://github.com/neighborhoods/Prefab/pull/242)