### PR TITLE
Allowed usage with PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^7.3",
+    "php": "^7.3|^8.0",
     "jsoumelidis/zend-sf-di-config": "^0.3",
     "doctrine/dbal": "2.7 - 2.12",
     "symfony/config": "^4.4",


### PR DESCRIPTION
## Change Notes
- Added PHP 8 support

## JIRA Issues
- [PREF-280](https://55places.atlassian.net/browse/PREF-280)

We created a PrefabFitness project with PHP 8, but we never released a Prefab version allowing PHP 8.
