### PR TITLE
APR-1372: add support for filter fields tracer tagging

### DIFF
--- a/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
+++ b/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
@@ -14,7 +14,8 @@ class Handler implements HandlerInterface
     use Repository\AwareTrait;
     use Prefab5\Psr\Http\Message\ServerRequest\AwareTrait;
     use Prefab5\SearchCriteria\ServerRequest\Builder\Factory\AwareTrait;
-
+/** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-useGlobalTracerRepositoryAwareTrait
+ */
     public function handle(\Psr\Http\Message\ServerRequestInterface $request) : \Psr\Http\Message\ResponseInterface
     {
         $this->setPsrHttpMessageServerRequest($request);
@@ -33,7 +34,11 @@ class Handler implements HandlerInterface
         $searchCriteriaBuilder->setPsrHttpMessageServerRequest($this->getPsrHttpMessageServerRequest());
         try {
             $searchCriteria = $searchCriteriaBuilder->build();
-            return $this->getPrimaryActorNameMapRepository()->get($searchCriteria);
+            $map = $this->getPrimaryActorNameMapRepository()->get($searchCriteria);
+
+/** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-callSetFilterFieldsTracerTag
+ */
+            return $map;
         } catch (\LogicException $exception) {
             throw new SearchCriteriaBuilderException($exception->getMessage());
         }
@@ -63,5 +68,7 @@ class Handler implements HandlerInterface
     {
         return $this->getPsrHttpMessageServerRequest()->getAttribute(\Zend\Expressive\Router\RouteResult::class);
     }
+/** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-setFilterFieldsTracerTag
+ */
 }
 

--- a/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
+++ b/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
@@ -35,7 +35,6 @@ class Handler implements HandlerInterface
         try {
             $searchCriteria = $searchCriteriaBuilder->build();
             $map = $this->getPrimaryActorNameMapRepository()->get($searchCriteria);
-
 /** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-callSetFilterFieldsTracerTag
  */
             return $map;

--- a/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.service.yml
+++ b/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.service.yml
@@ -6,5 +6,5 @@ services:
     calls:
       - [setPrimaryActorNameMapRepository, ['@Neighborhoods\BuphaloTemplateTree\PrimaryActorName\Map\RepositoryInterface']]
       - [setSearchCriteriaServerRequestBuilderFactory, ['@PREFAB_PLACEHOLDER_VENDOR\PREFAB_PLACEHOLDER_PRODUCT\Prefab5\SearchCriteria\ServerRequest\Builder\FactoryInterface']]
-/** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerService-callSetGlobalTracerRepository
+/** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerServiceFile-callSetGlobalTracerRepository
  */

--- a/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.service.yml
+++ b/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.service.yml
@@ -6,3 +6,5 @@ services:
     calls:
       - [setPrimaryActorNameMapRepository, ['@Neighborhoods\BuphaloTemplateTree\PrimaryActorName\Map\RepositoryInterface']]
       - [setSearchCriteriaServerRequestBuilderFactory, ['@PREFAB_PLACEHOLDER_VENDOR\PREFAB_PLACEHOLDER_PRODUCT\Prefab5\SearchCriteria\ServerRequest\Builder\FactoryInterface']]
+/** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerService-callSetGlobalTracerRepository
+ */

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The file MUST be named {ACTORNAME}.prefab.definition.yml and saved under `src/`.
 - `tag_filter_fields_on_tracer`
     - This field is optional and default to `false`
     - Set to `true` if you want to tag on the default global tracer all the filter fields sent to `Map\Repository\Handler`.
+    - Note: to access the global tracer, the code uses the `neighborhoods/datadog-component` package. The Symfony container for your endpoint will not build unless you include the package source path in the list of `appended_paths` inside the `http-buildable-directories.yml` file, under the `top_level_key` of your endpoint. The source path is usually `vendor/neighborhoods/datadog-component/src`.
 - `json_serialize_map_as_array`
     - This field is optional and default to `false`
     - Set to `true` when HTTP response containing actor map should be a JSON array rather than an object with numerical property names.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ The file MUST be named {ACTORNAME}.prefab.definition.yml and saved under `src/`.
     - Can be one of `complete`, `collection`, `minimal`, `handler` or `repository`
     - This field is optional and defaults to `complete`
     - See [below](#supporting-actor-groups) for more information
+- `tag_filter_fields_on_tracer`
+    - This field is optional and default to `false`
+    - Set to `true` if you want to tag on the default global tracer all the filter fields sent to `Map\Repository\Handler`.
 - `http_route`
     - The HTTP route to access the actor
     - This field is optional and unnecessary if you don't want to expose the actor to HTTP traffic

--- a/src/ActorConfiguration/Actor/Map/Repository/Handler.php
+++ b/src/ActorConfiguration/Actor/Map/Repository/Handler.php
@@ -3,9 +3,26 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\ActorConfiguration\Actor\Map\Repository;
 
+use Neighborhoods\Prefab\AnnotationProcessorRecordInterface;
 interface Handler
 {
     public const ACTOR_KEY = '<PrimaryActorName>/Map/Repository/Handler.php';
     public const TEMPLATE_PATH = 'PrimaryActorName/Map/Repository/Handler.php';
-    public const ANNOTATION_PROCESSORS = [];
+    public const ANNOTATION_PROCESSORS = [
+        [
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerUseGlobalTracerRepositoryAwareTrait::ANNOTATION_PROCESSOR_KEY,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Map\Repository\Handler\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerUseGlobalTracerRepositoryAwareTrait::class,
+        ],
+        [
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerSetFilterFieldsTracerTag::ANNOTATION_PROCESSOR_KEY,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Map\Repository\Handler\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerSetFilterFieldsTracerTag::class,
+        ],
+        [
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerCallSetFilterFieldsTracerTag::ANNOTATION_PROCESSOR_KEY,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Map\Repository\Handler\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerCallSetFilterFieldsTracerTag::class,
+        ]
+    ];
 }

--- a/src/ActorConfiguration/Actor/Map/Repository/HandlerServiceFile.php
+++ b/src/ActorConfiguration/Actor/Map/Repository/HandlerServiceFile.php
@@ -3,9 +3,16 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\ActorConfiguration\Actor\Map\Repository;
 
+use Neighborhoods\Prefab\AnnotationProcessorRecordInterface;
 interface HandlerServiceFile
 {
     public const ACTOR_KEY = '<PrimaryActorName>/Map/Repository/Handler.service.yml';
     public const TEMPLATE_PATH = 'PrimaryActorName/Map/Repository/Handler.service.yml';
-    public const ANNOTATION_PROCESSORS = [];
+    public const ANNOTATION_PROCESSORS = [
+        [
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerServiceFile::ANNOTATION_PROCESSOR_KEY,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Map\Repository\Handler\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerServiceFile::class,
+        ]
+    ];
 }

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
@@ -6,13 +6,11 @@ namespace Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository;
 use Neighborhoods\Buphalo\V1\AnnotationProcessor\ContextInterface;
 use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
 
-class HandlerCallSetFilterFieldsTracerTag implements AnnotationProcessorInterface
+class HandlerCallSetFilterFieldsTracerTag implements AnnotationProcessorInterface, HandlerInterface
 {
     protected $context;
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-callSetFilterFieldsTracerTag';
-
-    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
 
     public function getAnnotationProcessorContext() : ContextInterface
     {

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository;
+
+use Neighborhoods\Buphalo\V1\AnnotationProcessor\ContextInterface;
+use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
+
+class HandlerCallSetFilterFieldsTracerTag implements AnnotationProcessorInterface
+{
+    protected $context;
+
+    public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-callSetFilterFieldsTracerTag';
+
+    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS = 'tag_filter_fields_on_tracer';
+
+    public function getAnnotationProcessorContext() : ContextInterface
+    {
+        if ($this->context === null) {
+            throw new \LogicException('Handler context has not been set.');
+        }
+        return $this->context;
+    }
+
+    public function setAnnotationProcessorContext(ContextInterface $context) : AnnotationProcessorInterface
+    {
+        if ($this->context !== null) {
+            throw new \LogicException('Handler context is already set.');
+        }
+        $this->context = $context;
+        return $this;
+    }
+
+    public function getReplacement() : string
+    {
+        $replacement = '';
+
+        $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
+        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) {
+            $replacement = <<< EOF
+            $this->setFilterFieldsTracerTag($searchCriteria);
+EOF;
+        }
+
+        return $replacement;
+    }
+}

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
@@ -37,6 +37,7 @@ class HandlerCallSetFilterFieldsTracerTag implements AnnotationProcessorInterfac
         if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
             $replacement = <<<'EOT'
             $this->setFilterFieldsTracerTag($searchCriteria);
+
 EOT;
         }
 

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
@@ -35,9 +35,9 @@ class HandlerCallSetFilterFieldsTracerTag implements AnnotationProcessorInterfac
 
         $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
         if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
-            $replacement = <<< EOF
+            $replacement = <<<'EOT'
             $this->setFilterFieldsTracerTag($searchCriteria);
-EOF;
+EOT;
         }
 
         return $replacement;

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerCallSetFilterFieldsTracerTag.php
@@ -12,7 +12,7 @@ class HandlerCallSetFilterFieldsTracerTag implements AnnotationProcessorInterfac
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-callSetFilterFieldsTracerTag';
 
-    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS = 'tag_filter_fields_on_tracer';
+    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
 
     public function getAnnotationProcessorContext() : ContextInterface
     {
@@ -36,7 +36,7 @@ class HandlerCallSetFilterFieldsTracerTag implements AnnotationProcessorInterfac
         $replacement = '';
 
         $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
-        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) {
+        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
             $replacement = <<< EOF
             $this->setFilterFieldsTracerTag($searchCriteria);
 EOF;

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerInterface.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerInterface.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository;
+
+interface HandlerInterface {
+    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
+}

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerServiceFile.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerServiceFile.php
@@ -6,13 +6,11 @@ namespace Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository;
 use Neighborhoods\Buphalo\V1\AnnotationProcessor\ContextInterface;
 use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
 
-class HandlerServiceFile implements AnnotationProcessorInterface
+class HandlerServiceFile implements AnnotationProcessorInterface, HandlerInterface
 {
     protected $context;
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerServiceFile-callSetGlobalTracerRepository';
-
-    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
 
     public function getAnnotationProcessorContext() : ContextInterface
     {

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerServiceFile.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerServiceFile.php
@@ -12,7 +12,7 @@ class HandlerServiceFile implements AnnotationProcessorInterface
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerServiceFile-callSetGlobalTracerRepository';
 
-    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS = 'tag_filter_fields_on_tracer';
+    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
 
     public function getAnnotationProcessorContext() : ContextInterface
     {
@@ -36,7 +36,7 @@ class HandlerServiceFile implements AnnotationProcessorInterface
         $replacement = '';
 
         $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
-        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) {
+        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
             $replacement = <<< EOF
         - [setGlobalTracerRepository, ['@Neighborhoods\DatadogComponent\GlobalTracer\RepositoryInterface']]
 EOF;

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerServiceFile.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerServiceFile.php
@@ -36,7 +36,7 @@ class HandlerServiceFile implements AnnotationProcessorInterface, HandlerInterfa
         $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
         if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
             $replacement = <<< EOF
-        - [setGlobalTracerRepository, ['@Neighborhoods\DatadogComponent\GlobalTracer\RepositoryInterface']]
+      - [setGlobalTracerRepository, ['@Neighborhoods\DatadogComponent\GlobalTracer\RepositoryInterface']]
 EOF;
         }
 

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerServiceFile.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerServiceFile.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository;
+
+use Neighborhoods\Buphalo\V1\AnnotationProcessor\ContextInterface;
+use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
+
+class HandlerServiceFile implements AnnotationProcessorInterface
+{
+    protected $context;
+
+    public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\HandlerServiceFile-callSetGlobalTracerRepository';
+
+    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS = 'tag_filter_fields_on_tracer';
+
+    public function getAnnotationProcessorContext() : ContextInterface
+    {
+        if ($this->context === null) {
+            throw new \LogicException('Handler context has not been set.');
+        }
+        return $this->context;
+    }
+
+    public function setAnnotationProcessorContext(ContextInterface $context) : AnnotationProcessorInterface
+    {
+        if ($this->context !== null) {
+            throw new \LogicException('Handler context is already set.');
+        }
+        $this->context = $context;
+        return $this;
+    }
+
+    public function getReplacement() : string
+    {
+        $replacement = '';
+
+        $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
+        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) {
+            $replacement = <<< EOF
+        - [setGlobalTracerRepository, ['@Neighborhoods\DatadogComponent\GlobalTracer\RepositoryInterface']]
+EOF;
+        }
+
+        return $replacement;
+    }
+}

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
@@ -12,7 +12,7 @@ class HandlerSetFilterFieldsTracerTag implements AnnotationProcessorInterface
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-setFilterFieldsTracerTag';
 
-    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS = 'tag_filter_fields_on_tracer';
+    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
 
     public function getAnnotationProcessorContext() : ContextInterface
     {
@@ -36,7 +36,7 @@ class HandlerSetFilterFieldsTracerTag implements AnnotationProcessorInterface
         $replacement = '';
 
         $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
-        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) {
+        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
             $replacement = <<< EOF
     private function setFilterFieldsTracerTag(Prefab5\SearchCriteriaInterface $searchCriteria): void {
 

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
@@ -36,6 +36,7 @@ class HandlerSetFilterFieldsTracerTag implements AnnotationProcessorInterface, H
         $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
         if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
             $replacement = <<<'EOT'
+
     private function setFilterFieldsTracerTag(Prefab5\SearchCriteriaInterface $searchCriteria): void {
 
         $filterFields = [];

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
@@ -6,13 +6,11 @@ namespace Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository;
 use Neighborhoods\Buphalo\V1\AnnotationProcessor\ContextInterface;
 use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
 
-class HandlerSetFilterFieldsTracerTag implements AnnotationProcessorInterface
+class HandlerSetFilterFieldsTracerTag implements AnnotationProcessorInterface, HandlerInterface
 {
     protected $context;
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-setFilterFieldsTracerTag';
-
-    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
 
     public function getAnnotationProcessorContext() : ContextInterface
     {

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
@@ -35,7 +35,7 @@ class HandlerSetFilterFieldsTracerTag implements AnnotationProcessorInterface, H
 
         $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
         if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
-            $replacement = <<< EOF
+            $replacement = <<<'EOT'
     private function setFilterFieldsTracerTag(Prefab5\SearchCriteriaInterface $searchCriteria): void {
 
         $filterFields = [];
@@ -55,7 +55,7 @@ class HandlerSetFilterFieldsTracerTag implements AnnotationProcessorInterface, H
         }
     }
 
-EOF;
+EOT;
         }
 
         return $replacement;

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
@@ -54,7 +54,6 @@ class HandlerSetFilterFieldsTracerTag implements AnnotationProcessorInterface, H
             $span->setTag('filter_fields', implode('-', $filterFields));
         }
     }
-
 EOT;
         }
 

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerSetFilterFieldsTracerTag.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository;
+
+use Neighborhoods\Buphalo\V1\AnnotationProcessor\ContextInterface;
+use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
+
+class HandlerSetFilterFieldsTracerTag implements AnnotationProcessorInterface
+{
+    protected $context;
+
+    public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-setFilterFieldsTracerTag';
+
+    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS = 'tag_filter_fields_on_tracer';
+
+    public function getAnnotationProcessorContext() : ContextInterface
+    {
+        if ($this->context === null) {
+            throw new \LogicException('Handler context has not been set.');
+        }
+        return $this->context;
+    }
+
+    public function setAnnotationProcessorContext(ContextInterface $context) : AnnotationProcessorInterface
+    {
+        if ($this->context !== null) {
+            throw new \LogicException('Handler context is already set.');
+        }
+        $this->context = $context;
+        return $this;
+    }
+
+    public function getReplacement() : string
+    {
+        $replacement = '';
+
+        $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
+        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) {
+            $replacement = <<< EOF
+    private function setFilterFieldsTracerTag(Prefab5\SearchCriteriaInterface $searchCriteria): void {
+
+        $filterFields = [];
+        foreach ($searchCriteria->getFilters() as $filter) {
+            $filterFields[] = $filter->getField();
+        }
+
+        if (!empty($filterFields)) {
+            ksort($filterFields);
+        }
+
+        $tracer = $this->getGlobalTracerRepository()->get();
+        $span = $tracer->getActiveSpan();
+
+        if ($span !== null) {
+            $span->setTag('filter_fields', implode('-', $filterFields));
+        }
+    }
+
+EOF;
+        }
+
+        return $replacement;
+    }
+}

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerUseGlobalTracerRepositoryAwareTrait.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerUseGlobalTracerRepositoryAwareTrait.php
@@ -12,7 +12,7 @@ class HandlerUseGlobalTracerRepositoryAwareTrait implements AnnotationProcessorI
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-useGlobalTracerRepositoryAwareTrait';
 
-    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS = 'tag_filter_fields_on_tracer';
+    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
 
     public function getAnnotationProcessorContext() : ContextInterface
     {
@@ -36,7 +36,7 @@ class HandlerUseGlobalTracerRepositoryAwareTrait implements AnnotationProcessorI
         $replacement = '';
 
         $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
-        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) {
+        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
             $replacement = <<< EOF
     use \Neighborhoods\DatadogComponent\GlobalTracer\Repository\AwareTrait;
 EOF;

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerUseGlobalTracerRepositoryAwareTrait.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerUseGlobalTracerRepositoryAwareTrait.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository;
+
+use Neighborhoods\Buphalo\V1\AnnotationProcessor\ContextInterface;
+use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
+
+class HandlerUseGlobalTracerRepositoryAwareTrait implements AnnotationProcessorInterface
+{
+    protected $context;
+
+    public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-useGlobalTracerRepositoryAwareTrait';
+
+    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS = 'tag_filter_fields_on_tracer';
+
+    public function getAnnotationProcessorContext() : ContextInterface
+    {
+        if ($this->context === null) {
+            throw new \LogicException('Handler context has not been set.');
+        }
+        return $this->context;
+    }
+
+    public function setAnnotationProcessorContext(ContextInterface $context) : AnnotationProcessorInterface
+    {
+        if ($this->context !== null) {
+            throw new \LogicException('Handler context is already set.');
+        }
+        $this->context = $context;
+        return $this;
+    }
+
+    public function getReplacement() : string
+    {
+        $replacement = '';
+
+        $record = $this->getAnnotationProcessorContext()->getStaticContextRecord();
+        if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS]) {
+            $replacement = <<< EOF
+    use \Neighborhoods\DatadogComponent\GlobalTracer\Repository\AwareTrait;
+EOF;
+        }
+
+        return $replacement;
+    }
+}

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerUseGlobalTracerRepositoryAwareTrait.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerUseGlobalTracerRepositoryAwareTrait.php
@@ -37,6 +37,7 @@ class HandlerUseGlobalTracerRepositoryAwareTrait implements AnnotationProcessorI
         if (isset($record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) && $record[self::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER]) {
             $replacement = <<< EOF
     use \Neighborhoods\DatadogComponent\GlobalTracer\Repository\AwareTrait;
+
 EOF;
         }
 

--- a/src/AnnotationProcessor/Actor/Map/Repository/HandlerUseGlobalTracerRepositoryAwareTrait.php
+++ b/src/AnnotationProcessor/Actor/Map/Repository/HandlerUseGlobalTracerRepositoryAwareTrait.php
@@ -6,13 +6,11 @@ namespace Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository;
 use Neighborhoods\Buphalo\V1\AnnotationProcessor\ContextInterface;
 use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
 
-class HandlerUseGlobalTracerRepositoryAwareTrait implements AnnotationProcessorInterface
+class HandlerUseGlobalTracerRepositoryAwareTrait implements AnnotationProcessorInterface, HandlerInterface
 {
     protected $context;
 
     public const ANNOTATION_PROCESSOR_KEY = 'Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-useGlobalTracerRepositoryAwareTrait';
-
-    public const STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
 
     public function getAnnotationProcessorContext() : ContextInterface
     {

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Map/Repository/Handler/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Map/Repository/Handler/Builder.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\Map\Repository\Handler;
+
+use Neighborhoods\Prefab\BuildConfigurationInterface;
+use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\BuilderInterface;
+use Neighborhoods\Prefab\AnnotationProcessor;
+
+class Builder implements BuilderInterface
+{
+    protected $buildConfiguration;
+
+    public function build() : array
+    {
+        $buildConfiguration = $this->getBuildConfiguration();
+
+        return [
+            AnnotationProcessor\Actor\Map\Repository\HandlerServiceFile::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS => $buildConfiguration->getTagFilterFieldsOnTracer(),
+        ];
+    }
+
+    protected function getBuildConfiguration() : BuildConfigurationInterface
+    {
+        if ($this->buildConfiguration === null) {
+            throw new \LogicException('Builder buildConfiguration has not been set.');
+        }
+        return $this->buildConfiguration;
+    }
+
+    public function setBuildConfiguration(BuildConfigurationInterface $buildConfiguration) : BuilderInterface
+    {
+        if ($this->buildConfiguration !== null) {
+            throw new \LogicException('Builder buildConfiguration is already set.');
+        }
+        $this->buildConfiguration = $buildConfiguration;
+        return $this;
+    }
+}

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Map/Repository/Handler/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/Map/Repository/Handler/Builder.php
@@ -16,7 +16,7 @@ class Builder implements BuilderInterface
         $buildConfiguration = $this->getBuildConfiguration();
 
         return [
-            AnnotationProcessor\Actor\Map\Repository\HandlerServiceFile::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS => $buildConfiguration->getTagFilterFieldsOnTracer(),
+            AnnotationProcessor\Actor\Map\Repository\HandlerInterface::STATIC_CONTEXT_RECORD_KEY_TAG_FILTER_FIELDS_ON_TRACER => $buildConfiguration->getTagFilterFieldsOnTracer(),
         ];
     }
 

--- a/src/BuildConfiguration.php
+++ b/src/BuildConfiguration.php
@@ -309,4 +309,26 @@ class BuildConfiguration implements BuildConfigurationInterface
     {
         return $this->daoPropertyMap !== null;
     }
+
+    public function setTagFilterFieldsOnTracer($tagFilterFieldsOnTracer): BuildConfigurationInterface
+    {
+        if (isset($this->tagFilterFieldsOnTracer)) {
+            throw new \LogicException('Tag Filter Fields On Tracer is already set.');
+        }
+        $this->tagFilterFieldsOnTracer = $tagFilterFieldsOnTracer;
+        return $this;
+    }
+
+    public function getTagFilterFieldsOnTracer()
+    {
+        if (!isset($this->tagFilterFieldsOnTracer)) {
+            throw new \LogicException('Tag Filter Fields On Tracer has not been set.');
+        }
+        return $this->tagFilterFieldsOnTracer;
+    }
+
+    public function hasTagFilterFieldsOnTracer() : bool
+    {
+        return $this->tagFilterFieldsOnTracer !== null;
+    }
 }

--- a/src/BuildConfiguration/Builder.php
+++ b/src/BuildConfiguration/Builder.php
@@ -42,6 +42,12 @@ class Builder implements BuilderInterface
             $buildConfiguration->setSupportingActorGroup(BuildConfigurationInterface::SUPPORTING_ACTOR_GROUP_COMPLETE);
         }
 
+        if (!empty($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_TAG_FILTER_FIELDS_ON_TRACER])) {
+            $buildConfiguration->setTagFilterFieldsOnTracer($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_TAG_FILTER_FIELDS_ON_TRACER]);
+        } else {
+            $buildConfiguration->setTagFilterFieldsOnTracer(false);
+        }
+
         if (!empty($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_TABLE_NAME])
             || $buildConfiguration->getSupportingActorGroup() !== 'handler') {
             $buildConfiguration->setTableName($prefabDefinitionFileArray[BuildConfigurationInterface::KEY_TABLE_NAME]);

--- a/src/BuildConfigurationInterface.php
+++ b/src/BuildConfigurationInterface.php
@@ -95,18 +95,16 @@ interface BuildConfigurationInterface
     public function setConstantMap(\Neighborhoods\Prefab\Constant\MapInterface $constantMap): BuildConfigurationInterface;
 
     public function hasConstantMap(): bool;
-
-<<<<<<< HEAD
+    
     public function setTagFilterFieldsOnTracer($tagFilterFieldsOnTracer): BuildConfigurationInterface;
 
     public function getTagFilterFieldsOnTracer();
 
     public function hasTagFilterFieldsOnTracer(): bool;
-=======
+
     public function setJsonSerializeMapAsArray($jsonSerializeMapAsArray): BuildConfigurationInterface;
 
     public function getJsonSerializeMapAsArray();
 
     public function hasJsonSerializeMapAsArray(): bool;
->>>>>>> 8.x
 }

--- a/src/BuildConfigurationInterface.php
+++ b/src/BuildConfigurationInterface.php
@@ -21,6 +21,7 @@ interface BuildConfigurationInterface
     public const KEY_HTTP_VERBS = 'http_verbs';
     public const HTTP_VERB_GET = 'GET';
     public const KEY_SUPPORTING_ACTOR_GROUP = 'supporting_actor_group';
+    public const KEY_TAG_FILTER_FIELDS_ON_TRACER = 'tag_filter_fields_on_tracer';
     public const KEY_PROPERTIES = 'properties';
     public const KEY_CONSTANTS = 'constants';
 
@@ -93,4 +94,10 @@ interface BuildConfigurationInterface
     public function setConstantMap(\Neighborhoods\Prefab\Constant\MapInterface $constantMap): BuildConfigurationInterface;
 
     public function hasConstantMap(): bool;
+
+    public function setTagFilterFieldsOnTracer($tagFilterFieldsOnTracer): BuildConfigurationInterface;
+
+    public function getTagFilterFieldsOnTracer();
+
+    public function hasTagFilterFieldsOnTracer(): bool;
 }


### PR DESCRIPTION
## Change Notes

- Added support for property `tag_filter_fields_on_tracer` so we can decide to tag the filter fields on Map\Repository\Handler

To explain in plain English, the idea is to have a flag to swtich on/off the use of the global tracer to tag every filter field that was sent to `Map\Repository\Handler`:

- if the tag is `true`, we add the machinery to get the global tracer instance inside the `Handler`, generate a string with the field names and set the tag on the tracer
- if the tag is `false`, the code stays the same as before

To allow this, I used annotation processors to insert the needed bits of code on the right places.

## JIRA Issues
- [APR-1372](https://55places.atlassian.net/browse/APR-1372)
