### PR TITLE
APR-1376: prevent the mapping of repository LogicExceptions to SearchCriteriaBuilderExceptions

### DIFF
--- a/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
+++ b/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
@@ -35,7 +35,7 @@ class Handler implements HandlerInterface
         try {
             $searchCriteria = $searchCriteriaBuilder->build();
         } catch (\LogicException $exception) {
-            throw new SearchCriteriaBuilderException($exception->getMessage());
+            throw (new SearchCriteriaBuilderException($exception->getMessage()))->setPrevious($exception);
         }
 
         $map = $this->getPrimaryActorNameMapRepository()->get($searchCriteria);

--- a/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
+++ b/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
@@ -35,7 +35,7 @@ class Handler implements HandlerInterface
         try {
             $searchCriteria = $searchCriteriaBuilder->build();
         } catch (\LogicException $exception) {
-            throw (new SearchCriteriaBuilderException($exception->getMessage()))->setPrevious($exception);
+            throw (new SearchCriteriaBuilderException('Failed to build search criteria from HTTP request'))->setPrevious($exception);
         }
 
         $map = $this->getPrimaryActorNameMapRepository()->get($searchCriteria);
@@ -71,4 +71,3 @@ class Handler implements HandlerInterface
 /** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-setFilterFieldsTracerTag
  */
 }
-

--- a/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
+++ b/BuphaloTemplates/Prefab5/PrimaryActorName/Map/Repository/Handler.php
@@ -34,13 +34,14 @@ class Handler implements HandlerInterface
         $searchCriteriaBuilder->setPsrHttpMessageServerRequest($this->getPsrHttpMessageServerRequest());
         try {
             $searchCriteria = $searchCriteriaBuilder->build();
-            $map = $this->getPrimaryActorNameMapRepository()->get($searchCriteria);
-/** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-callSetFilterFieldsTracerTag
- */
-            return $map;
         } catch (\LogicException $exception) {
             throw new SearchCriteriaBuilderException($exception->getMessage());
         }
+
+        $map = $this->getPrimaryActorNameMapRepository()->get($searchCriteria);
+        /** @neighborhoods-buphalo:annotation-processor Neighborhoods\Prefab\AnnotationProcessor\Actor\Map\Repository\Handler-callSetFilterFieldsTracerTag
+         */
+        return $map;
     }
 
     protected function post()

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -102,3 +102,9 @@ return (new \Neighborhoods\DependencyInjectionContainerBuilderComponent\TinyCont
 
  * `Neighborhoods\Prefab\Protean\Container\Builder` class has been removed. It is **unlikely** that you use this class directly. If you use it, have a look at changes on `Neighborhoods\Prefab\Prefab` which used it as well.
  * `Neighborhoods\Prefab\Prefab` requires you to set the application root directory path on it, instead of passing a protean container builder having it set. It is **unlikely** that you use this class directly. If you use it have a look at changes on the `bin/prefab` script.
+
+## Improvements
+
+Until Prefab 8.7.1 the template for the Handler's was converting repository exceptions into `SearchCriteriaBuilderException`.
+
+Check if your handler code is based on the template. If so please modify it according to [this PR](https://github.com/neighborhoods/Prefab/pull/257/files).


### PR DESCRIPTION
## Change Notes
- Updated the Map/Repository/Handler template so the LogicExceptions thrown by the Repository does not get mapped to a SearchCriteriaBuilderException
- Fixed the SearchCriteriaBuilderException construction to set the previous caught exception so we keep the error stack trace

This change is motivated by the fact that LogicExceptions thrown by the repository (or some component inside it) are not related to the search criteria used to make the request, but to some error while building the maps or the entities of the repository result.

Aside from that, as we return a `400 Bad Request` when some `SearchCriteriaBuilderException` happens, the requester may be misleaded by the response and try to fix the request, when in fact the problem is an `Internal Server Error`.

This PR fixes the template to change this behavior.

Note: as we are suggesting some change in the `Handler` already (#256), it is a good idea to wait for the merge of it before checking this new PR.

## JIRA Issues
- [APR-1376](https://55places.atlassian.net/browse/APR-1376)
