### PR TITLE
Use spaces for indentation on the Builder actor

### DIFF
--- a/src/AnnotationProcessor/Actor/Builder.php
+++ b/src/AnnotationProcessor/Actor/Builder.php
@@ -31,7 +31,7 @@ EOF;
         );
 EOF;
     protected const NON_COMPLEX_OBJECT_METHOD_PATTERN =
-"\t\t\$PrimaryActorName->set%s(%s\$record[PrimaryActorNameInterface::PROP_%s]);";
+"        \$PrimaryActorName->set%s(%s\$record[PrimaryActorNameInterface::PROP_%s]);";
 
     protected const NULLABLE_PROPERTY_METHOD_PATTERN = <<< EOF
         if (isset(\$record[PrimaryActorNameInterface::PROP_%s])) {
@@ -157,7 +157,7 @@ EOF;
                 trim($method)
             );
         } else {
-            return '   ' . $method . "\n";
+            return $method . "\n";
         }
     }
 }

--- a/src/AnnotationProcessor/Actor/BuilderFactoryTrait.php
+++ b/src/AnnotationProcessor/Actor/BuilderFactoryTrait.php
@@ -50,7 +50,7 @@ class BuilderFactoryTrait implements AnnotationProcessorInterface
                 && !in_array($property[self::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE], $builtTraits)
             ) {
                 $dataType = str_replace('Interface', '', $property[self::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE]);
-                $replacement .= "\tuse " . $dataType . '\\Builder\\Factory\\AwareTrait;' . PHP_EOL;
+                $replacement .= "    use " . $dataType . '\\Builder\\Factory\\AwareTrait;' . PHP_EOL;
                 $builtTraits[] = $property[self::STATIC_CONTEXT_RECORD_KEY_DATA_TYPE];
             }
         }


### PR DESCRIPTION
## Change Notes

- Updated the `NON_COMPLEX_OBJECT_METHOD_PATTERN` pattern to use spaces for indentation
- Updated the `getSetterForNonComplexObject` method to not add the extra spaces on the setter string
- Updated the Aware Traits annotation processor to use spaces instead of tabs

This PR is a suggestion.

I detected some indentation problems on the generated Builder, after I copied it to the `src/` folder to customize it.

It is possible to fix the indentation on the customized file, but it seems smart to also fix the generated one in the first place.