### PR TITLE
PREF-314 | support actor property deprecation

### DIFF
--- a/BuphaloTemplates/Prefab5/PrimaryActorName.php
+++ b/BuphaloTemplates/Prefab5/PrimaryActorName.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Neighborhoods\BuphaloTemplateTree;
 
+/** @neighborhoods-buphalo:annotation-processor UseNamespaces
+ */
+
 class PrimaryActorName implements PrimaryActorNameInterface
 {
 /** @neighborhoods-buphalo:annotation-processor DaoPropertiesAndAccessors

--- a/BuphaloTemplates/Prefab5/PrimaryActorNameInterface.php
+++ b/BuphaloTemplates/Prefab5/PrimaryActorNameInterface.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Neighborhoods\BuphaloTemplateTree;
 
+/** @neighborhoods-buphalo:annotation-processor UseNamespaces
+ */
+
 interface PrimaryActorNameInterface extends \JsonSerializable
 {
 /** @neighborhoods-buphalo:annotation-processor TableName

--- a/fab/AnnotationProcessorRecord.php
+++ b/fab/AnnotationProcessorRecord.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab;
 
+
+
 class AnnotationProcessorRecord implements AnnotationProcessorRecordInterface
 {
     /** @var string */
@@ -14,79 +16,79 @@ class AnnotationProcessorRecord implements AnnotationProcessorRecordInterface
     /** @var string */
     private $annotationProcessorKey;
 
-     public function getProcessorFullyQualifiedClassname(): string
-     {
-         if ($this->processorFullyQualifiedClassname === null) {
-             throw new \LogicException('processorFullyQualifiedClassname has not been set');
-         }
-         
-         return $this->processorFullyQualifiedClassname;
-     }
-     
-     public function setProcessorFullyQualifiedClassname(string $processorFullyQualifiedClassname): AnnotationProcessorRecordInterface
-     {
-         if ($this->processorFullyQualifiedClassname !== null) {
-             throw new \LogicException('processorFullyQualifiedClassname has already been set');
-         }
-         
-         $this->processorFullyQualifiedClassname = $processorFullyQualifiedClassname;
-         return $this;
-     }
-     
-     public function hasProcessorFullyQualifiedClassname(): bool
-     {
+    public function getProcessorFullyQualifiedClassname(): string
+    {
+        if ($this->processorFullyQualifiedClassname === null) {
+            throw new \LogicException('processorFullyQualifiedClassname has not been set');
+        }
+        
+        return $this->processorFullyQualifiedClassname;
+    }
+    
+    public function setProcessorFullyQualifiedClassname(string $processorFullyQualifiedClassname): AnnotationProcessorRecordInterface
+    {
+        if ($this->processorFullyQualifiedClassname !== null) {
+            throw new \LogicException('processorFullyQualifiedClassname has already been set');
+        }
+        
+        $this->processorFullyQualifiedClassname = $processorFullyQualifiedClassname;
+        return $this;
+    }
+    
+    public function hasProcessorFullyQualifiedClassname(): bool
+    {
         return $this->processorFullyQualifiedClassname !== null;
-     }
+    }
      
 
-     public function getStaticContextRecord(): array
-     {
-         if ($this->staticContextRecord === null) {
-             throw new \LogicException('staticContextRecord has not been set');
-         }
-         
-         return $this->staticContextRecord;
-     }
-     
-     public function setStaticContextRecord(array $staticContextRecord): AnnotationProcessorRecordInterface
-     {
-         if ($this->staticContextRecord !== null) {
-             throw new \LogicException('staticContextRecord has already been set');
-         }
-         
-         $this->staticContextRecord = $staticContextRecord;
-         return $this;
-     }
-     
-     public function hasStaticContextRecord(): bool
-     {
+    public function getStaticContextRecord(): array
+    {
+        if ($this->staticContextRecord === null) {
+            throw new \LogicException('staticContextRecord has not been set');
+        }
+        
+        return $this->staticContextRecord;
+    }
+    
+    public function setStaticContextRecord(array $staticContextRecord): AnnotationProcessorRecordInterface
+    {
+        if ($this->staticContextRecord !== null) {
+            throw new \LogicException('staticContextRecord has already been set');
+        }
+        
+        $this->staticContextRecord = $staticContextRecord;
+        return $this;
+    }
+    
+    public function hasStaticContextRecord(): bool
+    {
         return $this->staticContextRecord !== null;
-     }
+    }
      
 
-     public function getAnnotationProcessorKey(): string
-     {
-         if ($this->annotationProcessorKey === null) {
-             throw new \LogicException('annotationProcessorKey has not been set');
-         }
-         
-         return $this->annotationProcessorKey;
-     }
-     
-     public function setAnnotationProcessorKey(string $annotationProcessorKey): AnnotationProcessorRecordInterface
-     {
-         if ($this->annotationProcessorKey !== null) {
-             throw new \LogicException('annotationProcessorKey has already been set');
-         }
-         
-         $this->annotationProcessorKey = $annotationProcessorKey;
-         return $this;
-     }
-     
-     public function hasAnnotationProcessorKey(): bool
-     {
+    public function getAnnotationProcessorKey(): string
+    {
+        if ($this->annotationProcessorKey === null) {
+            throw new \LogicException('annotationProcessorKey has not been set');
+        }
+        
+        return $this->annotationProcessorKey;
+    }
+    
+    public function setAnnotationProcessorKey(string $annotationProcessorKey): AnnotationProcessorRecordInterface
+    {
+        if ($this->annotationProcessorKey !== null) {
+            throw new \LogicException('annotationProcessorKey has already been set');
+        }
+        
+        $this->annotationProcessorKey = $annotationProcessorKey;
+        return $this;
+    }
+    
+    public function hasAnnotationProcessorKey(): bool
+    {
         return $this->annotationProcessorKey !== null;
-     }
+    }
      
 
     public function jsonSerialize()

--- a/fab/AnnotationProcessorRecord/StaticContextRecord.php
+++ b/fab/AnnotationProcessorRecord/StaticContextRecord.php
@@ -3,34 +3,36 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\AnnotationProcessorRecord;
 
+
+
 class StaticContextRecord implements StaticContextRecordInterface
 {
     /** @var string */
     private $processorFullyQualifiedClassname;
 
-     public function getProcessorFullyQualifiedClassname(): string
-     {
-         if ($this->processorFullyQualifiedClassname === null) {
-             throw new \LogicException('processorFullyQualifiedClassname has not been set');
-         }
-         
-         return $this->processorFullyQualifiedClassname;
-     }
-     
-     public function setProcessorFullyQualifiedClassname(string $processorFullyQualifiedClassname): StaticContextRecordInterface
-     {
-         if ($this->processorFullyQualifiedClassname !== null) {
-             throw new \LogicException('processorFullyQualifiedClassname has already been set');
-         }
-         
-         $this->processorFullyQualifiedClassname = $processorFullyQualifiedClassname;
-         return $this;
-     }
-     
-     public function hasProcessorFullyQualifiedClassname(): bool
-     {
+    public function getProcessorFullyQualifiedClassname(): string
+    {
+        if ($this->processorFullyQualifiedClassname === null) {
+            throw new \LogicException('processorFullyQualifiedClassname has not been set');
+        }
+        
+        return $this->processorFullyQualifiedClassname;
+    }
+    
+    public function setProcessorFullyQualifiedClassname(string $processorFullyQualifiedClassname): StaticContextRecordInterface
+    {
+        if ($this->processorFullyQualifiedClassname !== null) {
+            throw new \LogicException('processorFullyQualifiedClassname has already been set');
+        }
+        
+        $this->processorFullyQualifiedClassname = $processorFullyQualifiedClassname;
+        return $this;
+    }
+    
+    public function hasProcessorFullyQualifiedClassname(): bool
+    {
         return $this->processorFullyQualifiedClassname !== null;
-     }
+    }
      
 
     public function jsonSerialize()

--- a/fab/AnnotationProcessorRecord/StaticContextRecordInterface.php
+++ b/fab/AnnotationProcessorRecord/StaticContextRecordInterface.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\AnnotationProcessorRecord;
 
+
+
 interface StaticContextRecordInterface extends \JsonSerializable
 {
 

--- a/fab/DaoProperty.php
+++ b/fab/DaoProperty.php
@@ -20,6 +20,12 @@ class DaoProperty implements DaoPropertyInterface
     /** @var bool */
     private $createdOnInsert;
 
+    /** @var bool */
+    private $deprecated;
+
+    /** @var string */
+    private $deprecated_message;
+
      public function getName(): string
      {
          if ($this->name === null) {
@@ -142,6 +148,56 @@ class DaoProperty implements DaoPropertyInterface
      public function hasCreatedOnInsert(): bool
      {
         return $this->createdOnInsert !== null;
+     }
+     
+
+     public function getDeprecated(): bool
+     {
+         if ($this->deprecated === null) {
+             throw new \LogicException('deprecated has not been set');
+         }
+         
+         return $this->deprecated;
+     }
+     
+     public function setDeprecated(bool $deprecated): DaoPropertyInterface
+     {
+         if ($this->deprecated !== null) {
+             throw new \LogicException('deprecated has already been set');
+         }
+         
+         $this->deprecated = $deprecated;
+         return $this;
+     }
+     
+     public function hasDeprecated(): bool
+     {
+        return $this->deprecated !== null;
+     }
+     
+
+     public function getDeprecatedMessage(): string
+     {
+         if ($this->deprecated_message === null) {
+             throw new \LogicException('deprecated_message has not been set');
+         }
+         
+         return $this->deprecated_message;
+     }
+     
+     public function setDeprecatedMessage(string $deprecated_message): DaoPropertyInterface
+     {
+         if ($this->deprecated_message !== null) {
+             throw new \LogicException('deprecated_message has already been set');
+         }
+         
+         $this->deprecated_message = $deprecated_message;
+         return $this;
+     }
+     
+     public function hasDeprecatedMessage(): bool
+     {
+        return $this->deprecated_message !== null;
      }
      
 

--- a/fab/DaoProperty.php
+++ b/fab/DaoProperty.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab;
 
+
+
 class DaoProperty implements DaoPropertyInterface
 {
     /** @var string */
@@ -21,7 +23,7 @@ class DaoProperty implements DaoPropertyInterface
     private $createdOnInsert;
 
     /** @var bool */
-    private $deprecated;
+    private $is_deprecated;
 
     /** @var string */
     private $deprecated_message;
@@ -29,204 +31,204 @@ class DaoProperty implements DaoPropertyInterface
     /** @var string */
     private $replacement;
 
-     public function getName(): string
-     {
-         if ($this->name === null) {
-             throw new \LogicException('name has not been set');
-         }
-         
-         return $this->name;
-     }
-     
-     public function setName(string $name): DaoPropertyInterface
-     {
-         if ($this->name !== null) {
-             throw new \LogicException('name has already been set');
-         }
-         
-         $this->name = $name;
-         return $this;
-     }
-     
-     public function hasName(): bool
-     {
+    public function getName(): string
+    {
+        if ($this->name === null) {
+            throw new \LogicException('name has not been set');
+        }
+        
+        return $this->name;
+    }
+    
+    public function setName(string $name): DaoPropertyInterface
+    {
+        if ($this->name !== null) {
+            throw new \LogicException('name has already been set');
+        }
+        
+        $this->name = $name;
+        return $this;
+    }
+    
+    public function hasName(): bool
+    {
         return $this->name !== null;
-     }
+    }
      
 
-     public function getDataType(): string
-     {
-         if ($this->dataType === null) {
-             throw new \LogicException('dataType has not been set');
-         }
-         
-         return $this->dataType;
-     }
-     
-     public function setDataType(string $dataType): DaoPropertyInterface
-     {
-         if ($this->dataType !== null) {
-             throw new \LogicException('dataType has already been set');
-         }
-         
-         $this->dataType = $dataType;
-         return $this;
-     }
-     
-     public function hasDataType(): bool
-     {
+    public function getDataType(): string
+    {
+        if ($this->dataType === null) {
+            throw new \LogicException('dataType has not been set');
+        }
+        
+        return $this->dataType;
+    }
+    
+    public function setDataType(string $dataType): DaoPropertyInterface
+    {
+        if ($this->dataType !== null) {
+            throw new \LogicException('dataType has already been set');
+        }
+        
+        $this->dataType = $dataType;
+        return $this;
+    }
+    
+    public function hasDataType(): bool
+    {
         return $this->dataType !== null;
-     }
+    }
      
 
-     public function getNullable(): bool
-     {
-         if ($this->nullable === null) {
-             throw new \LogicException('nullable has not been set');
-         }
-         
-         return $this->nullable;
-     }
-     
-     public function setNullable(bool $nullable): DaoPropertyInterface
-     {
-         if ($this->nullable !== null) {
-             throw new \LogicException('nullable has already been set');
-         }
-         
-         $this->nullable = $nullable;
-         return $this;
-     }
-     
-     public function hasNullable(): bool
-     {
+    public function getNullable(): bool
+    {
+        if ($this->nullable === null) {
+            throw new \LogicException('nullable has not been set');
+        }
+        
+        return $this->nullable;
+    }
+    
+    public function setNullable(bool $nullable): DaoPropertyInterface
+    {
+        if ($this->nullable !== null) {
+            throw new \LogicException('nullable has already been set');
+        }
+        
+        $this->nullable = $nullable;
+        return $this;
+    }
+    
+    public function hasNullable(): bool
+    {
         return $this->nullable !== null;
-     }
+    }
      
 
-     public function getRecordKey(): string
-     {
-         if ($this->recordKey === null) {
-             throw new \LogicException('recordKey has not been set');
-         }
-         
-         return $this->recordKey;
-     }
-     
-     public function setRecordKey(string $recordKey): DaoPropertyInterface
-     {
-         if ($this->recordKey !== null) {
-             throw new \LogicException('recordKey has already been set');
-         }
-         
-         $this->recordKey = $recordKey;
-         return $this;
-     }
-     
-     public function hasRecordKey(): bool
-     {
+    public function getRecordKey(): string
+    {
+        if ($this->recordKey === null) {
+            throw new \LogicException('recordKey has not been set');
+        }
+        
+        return $this->recordKey;
+    }
+    
+    public function setRecordKey(string $recordKey): DaoPropertyInterface
+    {
+        if ($this->recordKey !== null) {
+            throw new \LogicException('recordKey has already been set');
+        }
+        
+        $this->recordKey = $recordKey;
+        return $this;
+    }
+    
+    public function hasRecordKey(): bool
+    {
         return $this->recordKey !== null;
-     }
+    }
      
 
-     public function getCreatedOnInsert(): bool
-     {
-         if ($this->createdOnInsert === null) {
-             throw new \LogicException('createdOnInsert has not been set');
-         }
-         
-         return $this->createdOnInsert;
-     }
-     
-     public function setCreatedOnInsert(bool $createdOnInsert): DaoPropertyInterface
-     {
-         if ($this->createdOnInsert !== null) {
-             throw new \LogicException('createdOnInsert has already been set');
-         }
-         
-         $this->createdOnInsert = $createdOnInsert;
-         return $this;
-     }
-     
-     public function hasCreatedOnInsert(): bool
-     {
+    public function getCreatedOnInsert(): bool
+    {
+        if ($this->createdOnInsert === null) {
+            throw new \LogicException('createdOnInsert has not been set');
+        }
+        
+        return $this->createdOnInsert;
+    }
+    
+    public function setCreatedOnInsert(bool $createdOnInsert): DaoPropertyInterface
+    {
+        if ($this->createdOnInsert !== null) {
+            throw new \LogicException('createdOnInsert has already been set');
+        }
+        
+        $this->createdOnInsert = $createdOnInsert;
+        return $this;
+    }
+    
+    public function hasCreatedOnInsert(): bool
+    {
         return $this->createdOnInsert !== null;
-     }
+    }
      
 
-     public function getDeprecated(): bool
-     {
-         if ($this->deprecated === null) {
-             throw new \LogicException('deprecated has not been set');
-         }
-         
-         return $this->deprecated;
-     }
-     
-     public function setDeprecated(bool $deprecated): DaoPropertyInterface
-     {
-         if ($this->deprecated !== null) {
-             throw new \LogicException('deprecated has already been set');
-         }
-         
-         $this->deprecated = $deprecated;
-         return $this;
-     }
-     
-     public function hasDeprecated(): bool
-     {
-        return $this->deprecated !== null;
-     }
+    public function getIsDeprecated(): bool
+    {
+        if ($this->is_deprecated === null) {
+            throw new \LogicException('is_deprecated has not been set');
+        }
+        
+        return $this->is_deprecated;
+    }
+    
+    public function setIsDeprecated(bool $is_deprecated): DaoPropertyInterface
+    {
+        if ($this->is_deprecated !== null) {
+            throw new \LogicException('is_deprecated has already been set');
+        }
+        
+        $this->is_deprecated = $is_deprecated;
+        return $this;
+    }
+    
+    public function hasIsDeprecated(): bool
+    {
+        return $this->is_deprecated !== null;
+    }
      
 
-     public function getDeprecatedMessage(): string
-     {
-         if ($this->deprecated_message === null) {
-             throw new \LogicException('deprecated_message has not been set');
-         }
-         
-         return $this->deprecated_message;
-     }
-     
-     public function setDeprecatedMessage(string $deprecated_message): DaoPropertyInterface
-     {
-         if ($this->deprecated_message !== null) {
-             throw new \LogicException('deprecated_message has already been set');
-         }
-         
-         $this->deprecated_message = $deprecated_message;
-         return $this;
-     }
-     
-     public function hasDeprecatedMessage(): bool
-     {
+    public function getDeprecatedMessage(): string
+    {
+        if ($this->deprecated_message === null) {
+            throw new \LogicException('deprecated_message has not been set');
+        }
+        
+        return $this->deprecated_message;
+    }
+    
+    public function setDeprecatedMessage(string $deprecated_message): DaoPropertyInterface
+    {
+        if ($this->deprecated_message !== null) {
+            throw new \LogicException('deprecated_message has already been set');
+        }
+        
+        $this->deprecated_message = $deprecated_message;
+        return $this;
+    }
+    
+    public function hasDeprecatedMessage(): bool
+    {
         return $this->deprecated_message !== null;
-     }
+    }
      
 
-     public function getReplacement(): string
-     {
-         if ($this->replacement === null) {
-             throw new \LogicException('replacement has not been set');
-         }
-         
-         return $this->replacement;
-     }
-     
-     public function setReplacement(string $replacement): DaoPropertyInterface
-     {
-         if ($this->replacement !== null) {
-             throw new \LogicException('replacement has already been set');
-         }
-         
-         $this->replacement = $replacement;
-         return $this;
-     }
-     
-     public function hasReplacement(): bool
-     {
+    public function getReplacement(): string
+    {
+        if ($this->replacement === null) {
+            throw new \LogicException('replacement has not been set');
+        }
+        
+        return $this->replacement;
+    }
+    
+    public function setReplacement(string $replacement): DaoPropertyInterface
+    {
+        if ($this->replacement !== null) {
+            throw new \LogicException('replacement has already been set');
+        }
+        
+        $this->replacement = $replacement;
+        return $this;
+    }
+    
+    public function hasReplacement(): bool
+    {
         return $this->replacement !== null;
-     }
+    }
      
 
     public function jsonSerialize()

--- a/fab/DaoProperty.php
+++ b/fab/DaoProperty.php
@@ -26,6 +26,9 @@ class DaoProperty implements DaoPropertyInterface
     /** @var string */
     private $deprecated_message;
 
+    /** @var string */
+    private $replacement;
+
      public function getName(): string
      {
          if ($this->name === null) {
@@ -198,6 +201,31 @@ class DaoProperty implements DaoPropertyInterface
      public function hasDeprecatedMessage(): bool
      {
         return $this->deprecated_message !== null;
+     }
+     
+
+     public function getReplacement(): string
+     {
+         if ($this->replacement === null) {
+             throw new \LogicException('replacement has not been set');
+         }
+         
+         return $this->replacement;
+     }
+     
+     public function setReplacement(string $replacement): DaoPropertyInterface
+     {
+         if ($this->replacement !== null) {
+             throw new \LogicException('replacement has already been set');
+         }
+         
+         $this->replacement = $replacement;
+         return $this;
+     }
+     
+     public function hasReplacement(): bool
+     {
+        return $this->replacement !== null;
      }
      
 

--- a/fab/DaoPropertyInterface.php
+++ b/fab/DaoPropertyInterface.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Prefab;
 
+
+
 interface DaoPropertyInterface extends \JsonSerializable
 {
 
@@ -29,9 +31,9 @@ interface DaoPropertyInterface extends \JsonSerializable
     public function setCreatedOnInsert(bool $createdOnInsert): DaoPropertyInterface;
     public function hasCreatedOnInsert(): bool;
 
-    public function getDeprecated(): bool;
-    public function setDeprecated(bool $deprecated): DaoPropertyInterface;
-    public function hasDeprecated(): bool;
+    public function getIsDeprecated(): bool;
+    public function setIsDeprecated(bool $is_deprecated): DaoPropertyInterface;
+    public function hasIsDeprecated(): bool;
 
     public function getDeprecatedMessage(): string;
     public function setDeprecatedMessage(string $deprecated_message): DaoPropertyInterface;

--- a/fab/DaoPropertyInterface.php
+++ b/fab/DaoPropertyInterface.php
@@ -28,4 +28,12 @@ interface DaoPropertyInterface extends \JsonSerializable
     public function getCreatedOnInsert(): bool;
     public function setCreatedOnInsert(bool $createdOnInsert): DaoPropertyInterface;
     public function hasCreatedOnInsert(): bool;
+
+    public function getDeprecated(): bool;
+    public function setDeprecated(bool $deprecated): DaoPropertyInterface;
+    public function hasDeprecated(): bool;
+
+    public function getDeprecatedMessage(): string;
+    public function setDeprecatedMessage(string $deprecated_message): DaoPropertyInterface;
+    public function hasDeprecatedMessage(): bool;
 }

--- a/fab/DaoPropertyInterface.php
+++ b/fab/DaoPropertyInterface.php
@@ -36,4 +36,8 @@ interface DaoPropertyInterface extends \JsonSerializable
     public function getDeprecatedMessage(): string;
     public function setDeprecatedMessage(string $deprecated_message): DaoPropertyInterface;
     public function hasDeprecatedMessage(): bool;
+
+    public function getReplacement(): string;
+    public function setReplacement(string $replacement): DaoPropertyInterface;
+    public function hasReplacement(): bool;
 }

--- a/src/ActorConfiguration/Actor.php
+++ b/src/ActorConfiguration/Actor.php
@@ -1,21 +1,31 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\ActorConfiguration;
 
 use Neighborhoods\Prefab\AnnotationProcessorRecordInterface;
+use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\DaoPropertiesAndAccessors;
+use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\UseNamespaces;
+use Neighborhoods\Prefab\AnnotationProcessor;
 
 interface Actor
 {
     public const ACTOR_KEY = '<PrimaryActorName>.php';
     public const TEMPLATE_PATH = 'PrimaryActorName.php';
     public const ANNOTATION_PROCESSOR_KEY_DAO_PROPERTIES_AND_ACCESSORS = 'DaoPropertiesAndAccessors';
+    public const ANNOTATION_PROCESSOR_KEY_USE_NAMESPACES = 'UseNamespaces';
 
     public const ANNOTATION_PROCESSORS = [
         [
             AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => self::ANNOTATION_PROCESSOR_KEY_DAO_PROPERTIES_AND_ACCESSORS,
-            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\DaoPropertiesAndAccessors\Builder::class,
-            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\DAO::class,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => DaoPropertiesAndAccessors\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => AnnotationProcessor\DAO::class,
         ],
+        [
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => self::ANNOTATION_PROCESSOR_KEY_USE_NAMESPACES,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => UseNamespaces\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => AnnotationProcessor\UseNamespaces::class,
+        ]
     ];
 }

--- a/src/ActorConfiguration/ActorInterface.php
+++ b/src/ActorConfiguration/ActorInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 namespace Neighborhoods\Prefab\ActorConfiguration;
 
 use Neighborhoods\Prefab\AnnotationProcessorRecordInterface;
+use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\ActorInterface\DaoPropertiesAndAccessors;
+use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\ActorInterface\TableName;
+use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\UseNamespaces;
+use Neighborhoods\Prefab\AnnotationProcessor;
 
 interface ActorInterface
 {
@@ -11,17 +15,23 @@ interface ActorInterface
     public const TEMPLATE_PATH = 'PrimaryActorNameInterface.php';
     public const ANNOTATION_PROCESSOR_KEY_DAO_PROPERTIES = 'DaoAccessors';
     public const ANNOTATION_PROCESSOR_KEY_TABLE_NAME = 'TableName';
+    public const ANNOTATION_PROCESSOR_KEY_USE_NAMESPACES = 'UseNamespaces';
 
     public const ANNOTATION_PROCESSORS = [
         [
             AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => self::ANNOTATION_PROCESSOR_KEY_DAO_PROPERTIES,
-            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\ActorInterface\DaoPropertiesAndAccessors\Builder::class,
-            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\DAOInterfaceProperties::class,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => DaoPropertiesAndAccessors\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => AnnotationProcessor\DAOInterfaceProperties::class,
         ],
         [
             AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => self::ANNOTATION_PROCESSOR_KEY_TABLE_NAME,
-            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => \Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\ActorInterface\TableName\Builder::class,
-            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => \Neighborhoods\Prefab\AnnotationProcessor\DAOInterfaceTableName::class,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => TableName\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => AnnotationProcessor\DAOInterfaceTableName::class,
         ],
+        [
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_KEY => self::ANNOTATION_PROCESSOR_KEY_USE_NAMESPACES,
+            AnnotationProcessorRecordInterface::KEY_STATIC_CONTEXT_RECORD_BUILDER => UseNamespaces\Builder::class,
+            AnnotationProcessorRecordInterface::KEY_ANNOTATION_PROCESSOR_FULLY_QUALIFIED_CLASS_NAME => AnnotationProcessor\UseNamespaces::class,
+        ]
     ];
 }

--- a/src/AnnotationProcessor/DAO.php
+++ b/src/AnnotationProcessor/DAO.php
@@ -39,12 +39,12 @@ class DAO implements AnnotationProcessorInterface
             $name = $field['name'];
             $type = $field['type'];
 
-            $deprecated = $field['deprecated'] ?? isset($field['deprecated_message']) || isset($field['replacement']);
+            $isDeprecated = $field['is_deprecated'] ?? isset($field['deprecated_message']) || isset($field['replacement']);
             $deprecatedMessage = $field['deprecated_message'] ?? null;
             $replacement = $field['replacement'] ?? null;
 
             $properties[] = $this->buildProperty($name, $type);
-            $accessors[] = $this->buildAccessors($name, $type, $deprecated, $deprecatedMessage, $replacement);
+            $accessors[] = $this->buildAccessors($name, $type, $isDeprecated, $deprecatedMessage, $replacement);
         }
 
         return implode(PHP_EOL . PHP_EOL, $properties) . PHP_EOL . PHP_EOL . implode(PHP_EOL . PHP_EOL, $accessors);
@@ -61,15 +61,15 @@ EOC;
     private function buildAccessors(
         string $propertyName,
         string $type,
-        bool $deprecated,
+        bool $isDeprecated,
         ?string $deprecatedMessage,
         ?string $replacement
     ): string {
         $pascalCaseName = $this->getPascalCaseName($propertyName);
         $interface = $this->getAnnotationProcessorContext()->getFabricationFile()->getFileName() . 'Interface';
-        $getterDeprecatedTag = $deprecated ? $this->buildDeprecatedTag('get', $deprecatedMessage, $replacement) : '';
-        $setterDeprecatedTag = $deprecated ? $this->buildDeprecatedTag('set', $deprecatedMessage, $replacement) : '';
-        $hasserDeprecatedTag = $deprecated ? $this->buildDeprecatedTag('has', $deprecatedMessage, $replacement) : '';
+        $getterDeprecatedTag = $isDeprecated ? $this->buildDeprecatedTag('get', $deprecatedMessage, $replacement) : '';
+        $setterDeprecatedTag = $isDeprecated ? $this->buildDeprecatedTag('set', $deprecatedMessage, $replacement) : '';
+        $hasserDeprecatedTag = $isDeprecated ? $this->buildDeprecatedTag('has', $deprecatedMessage, $replacement) : '';
 
         return <<<EOC
     {$getterDeprecatedTag}public function get$pascalCaseName(): $type

--- a/src/AnnotationProcessor/DAO.php
+++ b/src/AnnotationProcessor/DAO.php
@@ -38,10 +38,13 @@ class DAO implements AnnotationProcessorInterface
         foreach ($context as $field) {
             $name = $field['name'];
             $type = $field['type'];
-            $deprecated = ($field['deprecated'] ?? false) ? $field['deprecated_message'] : null;
+
+            $deprecated = $field['deprecated'] ?? isset($field['deprecated_message']) || isset($field['replacement']);
+            $deprecatedMessage = $field['deprecated_message'] ?? null;
+            $replacement = $field['replacement'] ?? null;
 
             $properties[] = $this->buildProperty($name, $type);
-            $accessors[] = $this->buildAccessors($name, $type, $deprecated);
+            $accessors[] = $this->buildAccessors($name, $type, $deprecated, $deprecatedMessage, $replacement);
         }
 
         return implode(PHP_EOL . PHP_EOL, $properties) . PHP_EOL . PHP_EOL . implode(PHP_EOL . PHP_EOL, $accessors);
@@ -53,41 +56,76 @@ class DAO implements AnnotationProcessorInterface
     /** @var $type */
     private \$$name;
 EOC;
-
     }
 
-    private function buildAccessors(string $propertyName, string $type, ?string $deprecated): string
-    {
+    private function buildAccessors(
+        string $propertyName,
+        string $type,
+        bool $deprecated,
+        ?string $deprecatedMessage,
+        ?string $replacement
+    ): string {
         $pascalCaseName = $this->getPascalCaseName($propertyName);
         $interface = $this->getAnnotationProcessorContext()->getFabricationFile()->getFileName() . 'Interface';
-        $deprecatedTag = $deprecated !== null ? "/** @deprecated $deprecated */" . PHP_EOL . '     ' : '';
+        $getterDeprecatedTag = $deprecated ? $this->buildDeprecatedTag('get', $deprecatedMessage, $replacement) : '';
+        $setterDeprecatedTag = $deprecated ? $this->buildDeprecatedTag('set', $deprecatedMessage, $replacement) : '';
+        $hasserDeprecatedTag = $deprecated ? $this->buildDeprecatedTag('has', $deprecatedMessage, $replacement) : '';
 
         return <<<EOC
-     {$deprecatedTag}public function get$pascalCaseName(): $type
-     {
-         if (\$this->$propertyName === null) {
-             throw new \LogicException('$propertyName has not been set');
-         }
-         
-         return \$this->$propertyName;
-     }
-     
-     {$deprecatedTag}public function set$pascalCaseName($type \$$propertyName): $interface
-     {
-         if (\$this->$propertyName !== null) {
-             throw new \LogicException('$propertyName has already been set');
-         }
-         
-         \$this->$propertyName = \$$propertyName;
-         return \$this;
-     }
-     
-     {$deprecatedTag}public function has$pascalCaseName(): bool
-     {
+    {$getterDeprecatedTag}public function get$pascalCaseName(): $type
+    {
+        if (\$this->$propertyName === null) {
+            throw new \LogicException('$propertyName has not been set');
+        }
+        
+        return \$this->$propertyName;
+    }
+    
+    {$setterDeprecatedTag}public function set$pascalCaseName($type \$$propertyName): $interface
+    {
+        if (\$this->$propertyName !== null) {
+            throw new \LogicException('$propertyName has already been set');
+        }
+        
+        \$this->$propertyName = \$$propertyName;
+        return \$this;
+    }
+    
+    {$hasserDeprecatedTag}public function has$pascalCaseName(): bool
+    {
         return \$this->$propertyName !== null;
-     }
+    }
      
 EOC;
+    }
+
+    /** @link https://blog.jetbrains.com/phpstorm/2020/10/phpstorm-2020-3-eap-4/#deprecated */
+    private function buildDeprecatedTag(string $method, ?string $message, ?string $replacement): string
+    {
+        $params = [];
+        if ($message) {
+            $params[] = sprintf('reason: \'%s\'', addslashes($message));
+        }
+
+        if ($replacement) {
+            $params[] = sprintf('replacement: \'%s\'', $this->buildReplacement($method, $replacement));
+        }
+
+        return sprintf('#[Deprecated(%s)]', implode(', ', $params)) . PHP_EOL . '    ';
+    }
+
+    private function buildReplacement(string $method, string $field): string
+    {
+        $pascalCaseName = $this->getPascalCaseName($field);
+        switch ($method) {
+            case 'get':
+            case 'has':
+                return "%class%->{$method}{$pascalCaseName}()";
+            case 'set':
+                return "%class%->{$method}{$pascalCaseName}(%parameter0%)";
+            default:
+                throw new \UnexpectedValueException("Unexpected method $method");
+        }
     }
 
     private function getPascalCaseName(string $propertyName): string

--- a/src/AnnotationProcessor/DAOInterfaceProperties.php
+++ b/src/AnnotationProcessor/DAOInterfaceProperties.php
@@ -48,9 +48,10 @@ class DAOInterfaceProperties implements AnnotationProcessorInterface
             $name = $field['name'];
             $type = $field['type'];
             $recordKey = $field['record_key'];
+            $deprecated = ($field['deprecated'] ?? false) ? $field['deprecated_message'] : null;
 
-            $constants[] = $this->buildPropertyConstant($name, $recordKey);
-            $accessors[] = $this->buildAccessors($name, $type);
+            $constants[] = $this->buildPropertyConstant($name, $recordKey, $deprecated);
+            $accessors[] = $this->buildAccessors($name, $type, $deprecated);
         }
 
         return
@@ -91,24 +92,26 @@ class DAOInterfaceProperties implements AnnotationProcessorInterface
         return '[ ' . implode(', ', $arrayItems) . ']';
     }
 
-    private function buildPropertyConstant(string $propertyName, string $recordKey) : string
+    private function buildPropertyConstant(string $propertyName, string $recordKey, ?string $deprecated) : string
     {
         $allUpperPropertyName = strtoupper($propertyName);
+        $deprecatedTag = $deprecated !== null ? "/** @deprecated $deprecated */" . PHP_EOL . '    ' : '';
 
         return <<<EOC
-    public const PROP_$allUpperPropertyName = '$recordKey';
+    {$deprecatedTag}public const PROP_$allUpperPropertyName = '$recordKey';
 EOC;
     }
 
-    private function buildAccessors(string $propertyName, string $type): string
+    private function buildAccessors(string $propertyName, string $type, ?string $deprecated): string
     {
         $pascalCaseName = $this->getPascalCaseName($propertyName);
         $interface = $this->getAnnotationProcessorContext()->getFabricationFile()->getFileName() . 'Interface';
+        $deprecatedTag = $deprecated !== null ? "/** @deprecated $deprecated */" . PHP_EOL . '    ' : '';
 
         return <<<EOC
-    public function get$pascalCaseName(): $type;
-    public function set$pascalCaseName($type \$$propertyName): $interface;
-    public function has$pascalCaseName(): bool;
+    {$deprecatedTag}public function get$pascalCaseName(): $type;
+    {$deprecatedTag}public function set$pascalCaseName($type \$$propertyName): $interface;
+    {$deprecatedTag}public function has$pascalCaseName(): bool;
 EOC;
     }
 

--- a/src/AnnotationProcessor/DAOInterfaceProperties.php
+++ b/src/AnnotationProcessor/DAOInterfaceProperties.php
@@ -49,18 +49,18 @@ class DAOInterfaceProperties implements AnnotationProcessorInterface
             $type = $field['type'];
             $recordKey = $field['record_key'];
 
-            $deprecated = $field['deprecated'] ?? isset($field['deprecated_message']) || isset($field['replacement']);
+            $isDeprecated = $field['is_deprecated'] ?? isset($field['deprecated_message']) || isset($field['replacement']);
             $deprecatedMessage = $field['deprecated_message'] ?? null;
             $replacement = $field['replacement'] ?? null;
 
             $constants[] = $this->buildPropertyConstant(
                 $name,
                 $recordKey,
-                $deprecated,
+                $isDeprecated,
                 $deprecatedMessage,
                 $replacement
             );
-            $accessors[] = $this->buildAccessors($name, $type, $deprecated, $deprecatedMessage, $replacement);
+            $accessors[] = $this->buildAccessors($name, $type, $isDeprecated, $deprecatedMessage, $replacement);
         }
 
         return
@@ -104,12 +104,12 @@ class DAOInterfaceProperties implements AnnotationProcessorInterface
     private function buildPropertyConstant(
         string $propertyName,
         string $recordKey,
-        bool $deprecated,
+        bool $isDeprecated,
         ?string $deprecatedMessage,
         ?string $replacement
     ): string {
         $allUpperPropertyName = strtoupper($propertyName);
-        $deprecatedTag = $deprecated ? $this->buildDeprecatedTag('const', $deprecatedMessage, $replacement) : '';
+        $deprecatedTag = $isDeprecated ? $this->buildDeprecatedTag('const', $deprecatedMessage, $replacement) : '';
 
         return <<<EOC
     {$deprecatedTag}public const PROP_$allUpperPropertyName = '$recordKey';
@@ -119,15 +119,15 @@ EOC;
     private function buildAccessors(
         string $propertyName,
         string $type,
-        bool $deprecated,
+        bool $isDeprecated,
         ?string $deprecatedMessage,
         ?string $replacement
     ): string {
         $pascalCaseName = $this->getPascalCaseName($propertyName);
         $interface = $this->getAnnotationProcessorContext()->getFabricationFile()->getFileName() . 'Interface';
-        $getterDeprecatedTag = $deprecated ? $this->buildDeprecatedTag('get', $deprecatedMessage, $replacement) : '';
-        $setterDeprecatedTag = $deprecated ? $this->buildDeprecatedTag('set', $deprecatedMessage, $replacement) : '';
-        $hasserDeprecatedTag = $deprecated ? $this->buildDeprecatedTag('has', $deprecatedMessage, $replacement) : '';
+        $getterDeprecatedTag = $isDeprecated ? $this->buildDeprecatedTag('get', $deprecatedMessage, $replacement) : '';
+        $setterDeprecatedTag = $isDeprecated ? $this->buildDeprecatedTag('set', $deprecatedMessage, $replacement) : '';
+        $hasserDeprecatedTag = $isDeprecated ? $this->buildDeprecatedTag('has', $deprecatedMessage, $replacement) : '';
 
         return <<<EOC
     {$getterDeprecatedTag}public function get$pascalCaseName(): $type;

--- a/src/AnnotationProcessor/UseNamespaces.php
+++ b/src/AnnotationProcessor/UseNamespaces.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Prefab\AnnotationProcessor;
+
+use Neighborhoods\Buphalo\V1\AnnotationProcessor\Context;
+use Neighborhoods\Buphalo\V1\AnnotationProcessorInterface;
+
+class UseNamespaces implements AnnotationProcessorInterface
+{
+    public const CONTEXT_KEY_USES = 'uses';
+
+    private const FORMAT_USE = 'use %s;';
+
+    use Context\AwareTrait {
+        getAnnotationProcessorContext as public;
+    }
+
+    public function getReplacement(): string
+    {
+        $context = $this->getAnnotationProcessorContext()->getStaticContextRecord();
+
+        return implode(
+            PHP_EOL,
+            array_map(
+                static function (string $namespace): string {
+                    return sprintf(self::FORMAT_USE, $namespace);
+                },
+                $context[self::CONTEXT_KEY_USES]
+            )
+        );
+    }
+}

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/DaoPropertiesAndAccessors/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/DaoPropertiesAndAccessors/Builder.php
@@ -20,7 +20,7 @@ class Builder implements BuilderInterface
             $staticContextRecord[] = [
                 'name' => $property->getName(),
                 'type' => $property->getDataType(),
-                'deprecated' => $property->getDeprecated(),
+                'is_deprecated' => $property->getIsDeprecated(),
                 'deprecated_message' => $property->getDeprecatedMessage(),
                 'replacement' => $property->getReplacement(),
             ];

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/DaoPropertiesAndAccessors/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/DaoPropertiesAndAccessors/Builder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\DaoPropertiesAndAccessors;
@@ -11,7 +12,7 @@ class Builder implements BuilderInterface
 {
     protected $buildConfiguration;
 
-    public function build() : array
+    public function build(): array
     {
         $buildConfiguration = $this->getBuildConfiguration();
         $staticContextRecord = [];
@@ -21,15 +22,15 @@ class Builder implements BuilderInterface
                 'name' => $property->getName(),
                 'type' => $property->getDataType(),
                 'is_deprecated' => $property->getIsDeprecated(),
-                'deprecated_message' => $property->getDeprecatedMessage(),
-                'replacement' => $property->getReplacement(),
+                'deprecated_message' => $property->hasDeprecatedMessage() ? $property->getDeprecatedMessage() : null,
+                'replacement' => $property->hasReplacement() ? $property->getReplacement() : null,
             ];
         }
 
         return $staticContextRecord;
     }
 
-    protected function getBuildConfiguration() : BuildConfigurationInterface
+    protected function getBuildConfiguration(): BuildConfigurationInterface
     {
         if ($this->buildConfiguration === null) {
             throw new \LogicException('Builder buildConfiguration has not been set.');
@@ -37,7 +38,7 @@ class Builder implements BuilderInterface
         return $this->buildConfiguration;
     }
 
-    public function setBuildConfiguration(BuildConfigurationInterface $buildConfiguration) : BuilderInterface
+    public function setBuildConfiguration(BuildConfigurationInterface $buildConfiguration): BuilderInterface
     {
         if ($this->buildConfiguration !== null) {
             throw new \LogicException('Builder buildConfiguration is already set.');

--- a/src/AnnotationProcessorRecord/StaticContextRecord/Actor/DaoPropertiesAndAccessors/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/Actor/DaoPropertiesAndAccessors/Builder.php
@@ -19,7 +19,9 @@ class Builder implements BuilderInterface
         foreach ($buildConfiguration->getDaoPropertyMap() as $property) {
             $staticContextRecord[] = [
                 'name' => $property->getName(),
-                'type' => $property->getDataType()
+                'type' => $property->getDataType(),
+                'deprecated' => $property->getDeprecated(),
+                'deprecated_message' => $property->getDeprecatedMessage(),
             ];
         }
 

--- a/src/AnnotationProcessorRecord/StaticContextRecord/ActorInterface/DaoPropertiesAndAccessors/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/ActorInterface/DaoPropertiesAndAccessors/Builder.php
@@ -30,7 +30,7 @@ class Builder implements BuilderInterface
                 'name' => $property->getName(),
                 'type' => $property->getDataType(),
                 'record_key' => $property->getRecordKey(),
-                'deprecated' => $property->getDeprecated(),
+                'is_deprecated' => $property->getIsDeprecated(),
                 'deprecated_message' => $property->getDeprecatedMessage(),
                 'replacement' => $property->getReplacement(),
             ];

--- a/src/AnnotationProcessorRecord/StaticContextRecord/ActorInterface/DaoPropertiesAndAccessors/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/ActorInterface/DaoPropertiesAndAccessors/Builder.php
@@ -32,6 +32,7 @@ class Builder implements BuilderInterface
                 'record_key' => $property->getRecordKey(),
                 'deprecated' => $property->getDeprecated(),
                 'deprecated_message' => $property->getDeprecatedMessage(),
+                'replacement' => $property->getReplacement(),
             ];
         }
 

--- a/src/AnnotationProcessorRecord/StaticContextRecord/ActorInterface/DaoPropertiesAndAccessors/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/ActorInterface/DaoPropertiesAndAccessors/Builder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\ActorInterface\DaoPropertiesAndAccessors;
@@ -11,7 +12,7 @@ class Builder implements BuilderInterface
 {
     protected $buildConfiguration;
 
-    public function build() : array
+    public function build(): array
     {
         $buildConfiguration = $this->getBuildConfiguration();
         $staticContextRecord = [];
@@ -31,15 +32,15 @@ class Builder implements BuilderInterface
                 'type' => $property->getDataType(),
                 'record_key' => $property->getRecordKey(),
                 'is_deprecated' => $property->getIsDeprecated(),
-                'deprecated_message' => $property->getDeprecatedMessage(),
-                'replacement' => $property->getReplacement(),
+                'deprecated_message' => $property->hasDeprecatedMessage() ? $property->getDeprecatedMessage() : null,
+                'replacement' => $property->hasReplacement() ? $property->getReplacement() : null,
             ];
         }
 
         return $staticContextRecord;
     }
 
-    public function getBuildConfiguration() : BuildConfigurationInterface
+    public function getBuildConfiguration(): BuildConfigurationInterface
     {
         if ($this->buildConfiguration === null) {
             throw new \LogicException('Builder buildConfiguration has not been set.');
@@ -47,7 +48,7 @@ class Builder implements BuilderInterface
         return $this->buildConfiguration;
     }
 
-    public function setBuildConfiguration(BuildConfigurationInterface $buildConfiguration) : BuilderInterface
+    public function setBuildConfiguration(BuildConfigurationInterface $buildConfiguration): BuilderInterface
     {
         if ($this->buildConfiguration !== null) {
             throw new \LogicException('Builder buildConfiguration is already set.');

--- a/src/AnnotationProcessorRecord/StaticContextRecord/ActorInterface/DaoPropertiesAndAccessors/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/ActorInterface/DaoPropertiesAndAccessors/Builder.php
@@ -20,7 +20,7 @@ class Builder implements BuilderInterface
             foreach ($this->getBuildConfiguration()->getConstantMap() as $constant) {
                 $staticContextRecord[DAOInterfaceProperties::STATIC_CONTEXT_RECORD_KEY_CONSTANTS][] = [
                     'name' => $constant->getName(),
-                    'value' => $constant->getValue()
+                    'value' => $constant->getValue(),
                 ];
             }
         }
@@ -29,7 +29,9 @@ class Builder implements BuilderInterface
             $staticContextRecord[DAOInterfaceProperties::STATIC_CONTEXT_RECORD_KEY_PROPERTIES][] = [
                 'name' => $property->getName(),
                 'type' => $property->getDataType(),
-                'record_key' => $property->getRecordKey()
+                'record_key' => $property->getRecordKey(),
+                'deprecated' => $property->getDeprecated(),
+                'deprecated_message' => $property->getDeprecatedMessage(),
             ];
         }
 

--- a/src/AnnotationProcessorRecord/StaticContextRecord/UseNamespaces/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/UseNamespaces/Builder.php
@@ -20,7 +20,7 @@ class Builder implements BuilderInterface
 
         $hasDeprecation = false;
         foreach ($buildConfiguration->getDaoPropertyMap() as $property) {
-            if ($property->getDeprecated()) {
+            if ($property->getIsDeprecated()) {
                 $hasDeprecation = true;
             }
         }

--- a/src/AnnotationProcessorRecord/StaticContextRecord/UseNamespaces/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/UseNamespaces/Builder.php
@@ -6,6 +6,7 @@ namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Use
 use Neighborhoods\Prefab\AnnotationProcessor\UseNamespaces;
 use Neighborhoods\Prefab\BuildConfigurationInterface;
 use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\BuilderInterface;
+use JetBrains\PhpStorm\Deprecated;
 
 class Builder implements BuilderInterface
 {
@@ -25,8 +26,7 @@ class Builder implements BuilderInterface
         }
 
         if ($hasDeprecation) {
-            // `require JetBrains/phpstorm-stubs` & use Deprecated::class instead?
-            $namespaces[] = 'JetBrains\\PhpStorm\\Deprecated';
+            $namespaces[] = Deprecated::class;
         }
 
         if (!empty($namespaces)) {

--- a/src/AnnotationProcessorRecord/StaticContextRecord/UseNamespaces/Builder.php
+++ b/src/AnnotationProcessorRecord/StaticContextRecord/UseNamespaces/Builder.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\Actor\DaoPropertiesAndAccessors;
+namespace Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\UseNamespaces;
 
+use Neighborhoods\Prefab\AnnotationProcessor\UseNamespaces;
 use Neighborhoods\Prefab\BuildConfigurationInterface;
-use Neighborhoods\Prefab\DaoPropertyInterface;
 use Neighborhoods\Prefab\AnnotationProcessorRecord\StaticContextRecord\BuilderInterface;
 
 class Builder implements BuilderInterface
@@ -15,15 +15,22 @@ class Builder implements BuilderInterface
     {
         $buildConfiguration = $this->getBuildConfiguration();
         $staticContextRecord = [];
+        $namespaces = [];
 
+        $hasDeprecation = false;
         foreach ($buildConfiguration->getDaoPropertyMap() as $property) {
-            $staticContextRecord[] = [
-                'name' => $property->getName(),
-                'type' => $property->getDataType(),
-                'deprecated' => $property->getDeprecated(),
-                'deprecated_message' => $property->getDeprecatedMessage(),
-                'replacement' => $property->getReplacement(),
-            ];
+            if ($property->getDeprecated()) {
+                $hasDeprecation = true;
+            }
+        }
+
+        if ($hasDeprecation) {
+            // `require JetBrains/phpstorm-stubs` & use Deprecated::class instead?
+            $namespaces[] = 'JetBrains\\PhpStorm\\Deprecated';
+        }
+
+        if (!empty($namespaces)) {
+            $staticContextRecord[UseNamespaces::CONTEXT_KEY_USES] = $namespaces;
         }
 
         return $staticContextRecord;

--- a/src/DaoProperty.buphalo.v1.fabrication.yml
+++ b/src/DaoProperty.buphalo.v1.fabrication.yml
@@ -15,7 +15,7 @@ actors:
             type: string
           - name: createdOnInsert
             type: bool
-          - name: deprecated
+          - name: is_deprecated
             type: bool
           - name: deprecated_message
             type: string
@@ -39,7 +39,7 @@ actors:
             type: string
           - name: createdOnInsert
             type: bool
-          - name: deprecated
+          - name: is_deprecated
             type: bool
           - name: deprecated_message
             type: string

--- a/src/DaoProperty.buphalo.v1.fabrication.yml
+++ b/src/DaoProperty.buphalo.v1.fabrication.yml
@@ -19,6 +19,8 @@ actors:
             type: bool
           - name: deprecated_message
             type: string
+          - name: replacement
+            type: string
   <PrimaryActorName>.service.yml:
     template: PrimaryActorName.service.yml
   <PrimaryActorName>Interface.php:
@@ -40,6 +42,8 @@ actors:
           - name: deprecated
             type: bool
           - name: deprecated_message
+            type: string
+          - name: replacement
             type: string
   <PrimaryActorName>/AwareTrait.php:
     template: PrimaryActorName/AwareTrait.php

--- a/src/DaoProperty.buphalo.v1.fabrication.yml
+++ b/src/DaoProperty.buphalo.v1.fabrication.yml
@@ -15,6 +15,10 @@ actors:
             type: string
           - name: createdOnInsert
             type: bool
+          - name: deprecated
+            type: bool
+          - name: deprecated_message
+            type: string
   <PrimaryActorName>.service.yml:
     template: PrimaryActorName.service.yml
   <PrimaryActorName>Interface.php:
@@ -33,6 +37,10 @@ actors:
             type: string
           - name: createdOnInsert
             type: bool
+          - name: deprecated
+            type: bool
+          - name: deprecated_message
+            type: string
   <PrimaryActorName>/AwareTrait.php:
     template: PrimaryActorName/AwareTrait.php
   <PrimaryActorName>/Factory.php:

--- a/src/DaoProperty/Builder.php
+++ b/src/DaoProperty/Builder.php
@@ -29,12 +29,12 @@ class Builder implements BuilderInterface
         $daoproperty->setReplacement($record['replacement'] ?? '');
         if (!$daoproperty->getIsDeprecated() && $daoproperty->getDeprecatedMessage() !== '') {
             throw new \UnexpectedValueException(
-                "deprecated_message {$daoproperty->getDeprecatedMessage()} is set for a non-deprecated property"
+                "deprecated_message '{$daoproperty->getDeprecatedMessage()}' is set for a non-deprecated property"
             );
         }
         if (!$daoproperty->getIsDeprecated() && $daoproperty->getReplacement() !== '') {
             throw new \UnexpectedValueException(
-                "replacement {$daoproperty->getReplacement()} is set for a non-deprecated property"
+                "replacement '{$daoproperty->getReplacement()}' is set for a non-deprecated property"
             );
         }
 

--- a/src/DaoProperty/Builder.php
+++ b/src/DaoProperty/Builder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Neighborhoods\Prefab\DaoProperty;
@@ -11,7 +12,7 @@ class Builder implements BuilderInterface
 
     protected $record;
 
-    public function build() : DaoPropertyInterface
+    public function build(): DaoPropertyInterface
     {
         $daoproperty = $this->getDaoPropertyFactory()->create();
         $record = $this->getRecord();
@@ -25,14 +26,22 @@ class Builder implements BuilderInterface
 
         $daoproperty->setDeprecated($record['deprecated'] ?? false);
         $daoproperty->setDeprecatedMessage($record['deprecated_message'] ?? '');
+        $daoproperty->setReplacement($record['replacement'] ?? '');
         if (!$daoproperty->getDeprecated() && $daoproperty->getDeprecatedMessage() !== '') {
-            throw new \UnexpectedValueException("deprecated_message {$daoproperty->getDeprecatedMessage()} is set for a non-deprecated property");
+            throw new \UnexpectedValueException(
+                "deprecated_message {$daoproperty->getDeprecatedMessage()} is set for a non-deprecated property"
+            );
+        }
+        if (!$daoproperty->getDeprecated() && $daoproperty->getReplacement() !== '') {
+            throw new \UnexpectedValueException(
+                "replacement {$daoproperty->getReplacement()} is set for a non-deprecated property"
+            );
         }
 
         return $daoproperty;
     }
 
-    protected function getRecord() : array
+    protected function getRecord(): array
     {
         if ($this->record === null) {
             throw new \LogicException('Builder record has not been set.');
@@ -41,7 +50,7 @@ class Builder implements BuilderInterface
         return $this->record;
     }
 
-    public function setRecord(array $record) : BuilderInterface
+    public function setRecord(array $record): BuilderInterface
     {
         if ($this->record !== null) {
             throw new \LogicException('Builder record is already set.');

--- a/src/DaoProperty/Builder.php
+++ b/src/DaoProperty/Builder.php
@@ -23,6 +23,12 @@ class Builder implements BuilderInterface
         $daoproperty->setRecordKey($record['record_key'] ?? $record['database_column_name']);
         $daoproperty->setCreatedOnInsert($record['created_on_insert'] ?? false);
 
+        $daoproperty->setDeprecated($record['deprecated'] ?? false);
+        $daoproperty->setDeprecatedMessage($record['deprecated_message'] ?? '');
+        if (!$daoproperty->getDeprecated() && $daoproperty->getDeprecatedMessage() !== '') {
+            throw new \UnexpectedValueException("deprecated_message {$daoproperty->getDeprecatedMessage()} is set for a non-deprecated property");
+        }
+
         return $daoproperty;
     }
 

--- a/src/DaoProperty/Builder.php
+++ b/src/DaoProperty/Builder.php
@@ -25,20 +25,35 @@ class Builder implements BuilderInterface
         $daoproperty->setCreatedOnInsert($record['created_on_insert'] ?? false);
 
         $daoproperty->setIsDeprecated($record['is_deprecated'] ?? false);
-        $daoproperty->setDeprecatedMessage($record['deprecated_message'] ?? '');
-        $daoproperty->setReplacement($record['replacement'] ?? '');
-        if (!$daoproperty->getIsDeprecated() && $daoproperty->getDeprecatedMessage() !== '') {
-            throw new \UnexpectedValueException(
-                "deprecated_message '{$daoproperty->getDeprecatedMessage()}' is set for a non-deprecated property"
-            );
-        }
-        if (!$daoproperty->getIsDeprecated() && $daoproperty->getReplacement() !== '') {
-            throw new \UnexpectedValueException(
-                "replacement '{$daoproperty->getReplacement()}' is set for a non-deprecated property"
-            );
+
+        if (!empty($record['deprecated_message'])) { // allow for empty or null in the prefab file
+            $daoproperty->setDeprecatedMessage($record['deprecated_message']);
         }
 
+        if (!empty($record['replacement'])) { // allow for empty or null in the prefab filet status
+            $daoproperty->setReplacement($record['replacement']);
+        }
+
+        $this->validateDaoProperty($daoproperty);
+
         return $daoproperty;
+    }
+
+    private function validateDaoProperty(DaoPropertyInterface $daoProperty): void
+    {
+        if (!$daoProperty->getIsDeprecated()) {
+            if ($daoProperty->hasDeprecatedMessage()) {
+                throw new \UnexpectedValueException(
+                    "deprecated_message '{$daoProperty->getDeprecatedMessage()}' is set for a non-deprecated property"
+                );
+            }
+
+            if ($daoProperty->hasReplacement()) {
+                throw new \UnexpectedValueException(
+                    "replacement '{$daoProperty->getReplacement()}' is set for a non-deprecated property"
+                );
+            }
+        }
     }
 
     protected function getRecord(): array

--- a/src/DaoProperty/Builder.php
+++ b/src/DaoProperty/Builder.php
@@ -24,15 +24,15 @@ class Builder implements BuilderInterface
         $daoproperty->setRecordKey($record['record_key'] ?? $record['database_column_name']);
         $daoproperty->setCreatedOnInsert($record['created_on_insert'] ?? false);
 
-        $daoproperty->setDeprecated($record['deprecated'] ?? false);
+        $daoproperty->setIsDeprecated($record['is_deprecated'] ?? false);
         $daoproperty->setDeprecatedMessage($record['deprecated_message'] ?? '');
         $daoproperty->setReplacement($record['replacement'] ?? '');
-        if (!$daoproperty->getDeprecated() && $daoproperty->getDeprecatedMessage() !== '') {
+        if (!$daoproperty->getIsDeprecated() && $daoproperty->getDeprecatedMessage() !== '') {
             throw new \UnexpectedValueException(
                 "deprecated_message {$daoproperty->getDeprecatedMessage()} is set for a non-deprecated property"
             );
         }
-        if (!$daoproperty->getDeprecated() && $daoproperty->getReplacement() !== '') {
+        if (!$daoproperty->getIsDeprecated() && $daoproperty->getReplacement() !== '') {
             throw new \UnexpectedValueException(
                 "replacement {$daoproperty->getReplacement()} is set for a non-deprecated property"
             );


### PR DESCRIPTION
Updated to reference JetBrains Deprecated Attribute. As far as I can tell, works just fine without needing to actually require the code in composer. PHP Doesn't attempt to load the class file until you go to use a method from it (like when calling `new`), but namespace resolution within a file still works (_e.g._ referencing `::class`)

See Fitness PR: https://github.com/neighborhoods/PrefabFitness/pull/32